### PR TITLE
Update getting-started.mdx

### DIFF
--- a/src/pages/docs/certificate-manager/getting-started.mdx
+++ b/src/pages/docs/certificate-manager/getting-started.mdx
@@ -83,6 +83,8 @@ Run the following command, substituting the values from your Authority's propert
 
 This command will download the CA Root certificate and configure your local `step` client to interact with the Authority.
 
+If desired, you can also use the `step` CLI to [install](https://smallstep.com/docs/step-cli/reference/certificate/install) the CA Root certificate to your system's truststore.
+
 ## Next Steps
 
 - With your initial configuration complete, it's time to explore [basic certificate operations](/docs/certificate-manager/basic-ops).


### PR DESCRIPTION
We had a user complain that they couldn't figure out how to install their Root Certificate and that this info should be in the Getting Started Guide.