### PR TITLE
Add Fedora support and update CentOS 8 to CentOS Stream 8.

### DIFF
--- a/src/pages/docs/ssh/client.mdx
+++ b/src/pages/docs/ssh/client.mdx
@@ -16,7 +16,8 @@ The following features are supported:
   * macOS (10.13 High Sierra or above)
   * Windows 10 (using PowerShell)
   * Ubuntu 18.04 LTS
-  * CentOS 7 and 8
+  * CentOS 7 and CentOS Stream 8
+  * Fedora (34 and 35)
   * Debian 10
 
 ## Instructions


### PR DESCRIPTION
This PR will add support for Fedora 34 and 35 and update CentOS 8 to CentOS Stream 8. CentOS 8 is now EOL.