### PR TITLE
Remove language that Arch packages use the Arch User Repository

### DIFF
--- a/src/pages/docs/step-ca/installation.mdx
+++ b/src/pages/docs/step-ca/installation.mdx
@@ -74,7 +74,7 @@ To uninstall, run `dpkg -r step-cli step-ca` and remove the configuration direct
 
 #### Arch Linux
 
-There are community-driven Arch Linux packages in the [Arch User Repository](https://aur.archlinux.org/).
+There are community-driven Arch Linux packages.
 
 You can use [pacman](https://www.archlinux.org/pacman/) to install the packages.
 

--- a/src/pages/docs/step-cli/installation.mdx
+++ b/src/pages/docs/step-cli/installation.mdx
@@ -43,7 +43,7 @@ To uninstall, run `sudo dpkg -r step-cli` and remove the `$HOME/.step` configura
 
 #### Arch Linux
 
-There is a community-maintained [`step-cli` package](https://archlinux.org/packages/community/x86_64/step-cli/) that uses the [Arch User Repository](https://aur.archlinux.org/).
+There is a community-maintained [`step-cli` package](https://archlinux.org/packages/community/x86_64/step-cli/).
 
 Use [pacman](https://www.archlinux.org/pacman/) to install `step`:
 


### PR DESCRIPTION
The `step` and `step-ca` packages are in the official [community](https://wiki.archlinux.org/title/Official_repositories#community) repository now, and thus the Arch User Repository statement can be removed.

The AUR (which is distinct from the community repository) doesn't use `pacman`, and in fact AUR packages require [additional steps](https://wiki.archlinux.org/title/Arch_User_Repository#Installing_and_upgrading_packages) to use. Many Arch users limit their use of the AUR, so it makes sense to update the install docs to reflect the (superior) current situation.

Thanks!