### PR TITLE
Add policy evaluation documentation

### DIFF
--- a/src/pages/docs/contents.yaml
+++ b/src/pages/docs/contents.yaml
@@ -81,7 +81,7 @@ step_ca:
     path: step-ca/acme-basics
   - title: Configuration
     path: step-ca/configuration
-  - title: Policy
+  - title: Policies
     path: step-ca/policies
   - title: Provisioners
     path: step-ca/provisioners

--- a/src/pages/docs/contents.yaml
+++ b/src/pages/docs/contents.yaml
@@ -81,6 +81,8 @@ step_ca:
     path: step-ca/acme-basics
   - title: Configuration
     path: step-ca/configuration
+  - title: Policy
+    path: step-ca/policies
   - title: Provisioners
     path: step-ca/provisioners
   - title: Templates

--- a/src/pages/docs/step-ca/certificate-authority-core-concepts.mdx
+++ b/src/pages/docs/step-ca/certificate-authority-core-concepts.mdx
@@ -18,6 +18,8 @@ certificate management may want to check out...
 
 - [Online X.509 Certificate Authority](#online-and-offline-x509-certificate-authority)
 - [Provisioners](#provisioners)
+- [Certificate Issuance Policies](#policies)
+- [Certificate Templates](#templates)
 - [Active vs. Passive Revocation](#active-vs-passive-revocation)
 - [Other Operational Modes](#other-operational-modes)
 
@@ -59,6 +61,29 @@ Unlike active revocation, certificates cannot be immedietely revoked.
 Therefore, certificates should have a shorter lifetime to reduce the value of a key that has been exfiltrated.
 
 ![passive revocation diagram](/graphics/passive-revocation.png)
+
+## Policies
+
+With certificate issuance policies administrators can configure what Subjects, SANs and Principals the CA is allowed to sign.
+An example of a policy is to only allow (strict) subdomains of `internal.example.com`, which would be encoded as `*.internal.example.com`.
+
+Visit the [`step-ca` policy](/docs/step-ca/policies) page to learn how certificate issuance policies work and how they can be configured.
+
+## Templates
+
+People use private CAs for all sorts of things, in many different contexts:
+web apps, mobile apps, code signing, cloud VM instances, SSH, IoT devices, etc.
+So `step-ca` must be flexible enough to handle a wide variety of flows.
+
+X.509 and SSH certificate templates open up these possibilities.
+With certificate templates, you can do things like:
+
+- Add custom SANs or extensions to X.509 certificates
+- Make longer certificate chains, with multiple intermediate CAs
+- Use SSH `force-command` or `source-address` extensions
+- Add conditionals around a certificate's parameters, and fail if they are not met
+
+Visit the [`step-ca` templates](/docs/step-ca/templates) page to learn how to use templates.
 
 ## Other operational modes
 

--- a/src/pages/docs/step-ca/configuration.mdx
+++ b/src/pages/docs/step-ca/configuration.mdx
@@ -24,7 +24,7 @@ learn how to configure your CA to:
 - [Environment Variables](#environment-variables)
 - [Basic Configuration Options](#basic-configuration-options)
 - [Provisioners](#provisioners)
-- [Certificate Issuance Policy](#policy)
+- [Certificate Issuance Policies](#policy)
 - [Certificate Templates](#templates)
 - [Databases](#databases)
   - [Badger](#badger)
@@ -288,8 +288,17 @@ different provisioners, their target use cases, and how to add, remove, and conf
 
 ## Policy
 
-With certificate issuance policies administrators can configure what Subjects, SANs and Principals the CA is allowed to sign.
-An example of a policy is to only allow (strict) subdomains of `internal.example.com`, which would be encoded as `*.internal.example.com`.
+Certificate issuance policies can be used to enforce which Subjects, SANs and Principals the CA is allowed to sign.
+They can be configured for X.509 certificates as well as SSH user and host certificates.
+Policies are evaluated before a certificate is signed.
+Some examples of policies you can configure are:
+
+- A `dns` rule for `www.example.com`, only matching the domain `www.example.com`
+- A `dns` rule for `*.internal.example.com`, matching all subdomains of `internal.example.com`.
+- An `ip` rule for the `192.168.0.0/24` CIDR, matching all IPs in the range from `192.168.0.0`-`192.168.0.255`.
+- An `email` rule for `@devops`, matching all SSH user principals in the `@devops` domain.
+- A `uri` rule for `*.example.com`, matching all URIs for subdomains of `example.com`, ignoring the URI scheme.
+
 Visit the [`step-ca` policy](/docs/step-ca/policies) page to learn how certificate issuance policies work and how they can be configured.
 
 <Alert severity="info">
@@ -305,19 +314,16 @@ Visit the [`step-ca` policy](/docs/step-ca/policies) page to learn how certifica
   </div>
 </Alert>
 
+
 ## Templates
 
-People use private CAs for all sorts of things, in many different contexts:
-web apps, mobile apps, code signing, cloud VM instances, SSH, IoT devices, etc.
-So `step-ca` must be flexible enough to handle a wide variety of flows.
+Using X.509 and SSH certificate templates administrators can configure information that gets processed and added to certificates.
+These include things like:
 
-X.509 and SSH certificate templates open up these possibilities.
-With certificate templates, you can do things like:
-
-- Add custom SANs or extensions to X.509 certificates
-- Make longer certificate chains, with multiple intermediate CAs
-- Use SSH `force-command` or `source-address` extensions
-- Add conditionals around a certificate's parameters, and fail if they are not met
+- Custom SANs or extensions for X.509 certificates
+- Create longer certificate chains, including multiple intermediate CAs
+- Embed SSH `force-command` or `source-address` extensions
+- Evaluate basic logic operations on certificate's parameters, and fail if requirements are not met
 
 Visit the [`step-ca` templates](/docs/step-ca/templates) page to learn how to use templates.
 

--- a/src/pages/docs/step-ca/configuration.mdx
+++ b/src/pages/docs/step-ca/configuration.mdx
@@ -98,6 +98,19 @@ CA's keys.
       "minUserSSHCertDuration": "5m",
       "maxUserSSHCertDuration": "24h",
       "defaultUserSSHCertDuration": "16h",
+      "policy": {
+        "x509": {
+          "allow": ["*.local"]
+        },
+        "ssh": {
+          "user": {
+            "allow": ["@local"]
+          },
+          "host": {
+            "allow": ["*.local"]
+          }
+        }
+      }
     },
   	"provisioners": [
   		{

--- a/src/pages/docs/step-ca/configuration.mdx
+++ b/src/pages/docs/step-ca/configuration.mdx
@@ -24,6 +24,7 @@ learn how to configure your CA to:
 - [Environment Variables](#environment-variables)
 - [Basic Configuration Options](#basic-configuration-options)
 - [Provisioners](#provisioners)
+- [Certificate Issuance Policy](#policy)
 - [Certificate Templates](#templates)
 - [Databases](#databases)
   - [Badger](#badger)
@@ -284,6 +285,25 @@ CA's keys.
 Provisioners are people or entities that are registered with the certificate authority and 
 authorized to issue certificates. Visit the [`step-ca` provisioners](/docs/step-ca/provisioners) page to learn about the 
 different provisioners, their target use cases, and how to add, remove, and configure them.
+
+## Policy
+
+With certificate issuance policies administrators can configure what Subjects, SANs and Principals the CA is allowed to sign.
+An example of a policy is to only allow (strict) subdomains of `internal.example.com`, which would be encoded as `*.internal.example.com`.
+Visit the [`step-ca` policy](/docs/step-ca/policies) page to learn how certificate issuance policies work and how they can be configured.
+
+<Alert severity="info">
+  <AlertTitle>Need more control?</AlertTitle>
+  <div>
+    A self-hosted <Code>step-ca</Code> instance can be configured with a policy on the authority level only.
+    In a <Link
+      external
+      href="https://smallstep.com/signup?product=cm"
+    >
+      free hosted smallstep Certificate Manager authority
+    </Link>, policies can be configured on the authority, on each provisioner, and on every ACME account.
+  </div>
+</Alert>
 
 ## Templates
 

--- a/src/pages/docs/step-ca/policies.mdx
+++ b/src/pages/docs/step-ca/policies.mdx
@@ -23,7 +23,7 @@ This means that rules for X.509 certificates will not be evaluated when an SSH u
       href="https://smallstep.com/signup?product=cm"
     >
       free hosted smallstep Certificate Manager authority
-    </Link>, policies can be configured on the authority, on each provisioner, and on every ACME account.
+    </Link>, policies can be configured on the authority, on each provisioner, and on every ACME account, providing more granular control.
   </div>
 </Alert>
 
@@ -202,4 +202,94 @@ principal   |johndoe            |johndoe                                |janedoe
 
 ## Policy Configuration
 
-TODO: using CLI; using ca.json
+Policies can be administered using the `step` CLI application.
+The commands are part of the [`step ca policy`](https://smallstep.com/docs/step-cli/reference/ca/policy) namespace.
+There are subcommands for administering `authority`, `provisioner` and `acme` policies.
+In a self-hosted `step-ca`, policies can be configured on the authority level.
+
+<Alert severity="info">
+  <AlertTitle>Need more control?</AlertTitle>
+  <div>
+    A self-hosted <Code>step-ca</Code> instance can only be configured with a policy on the authority level.
+    In a <Link
+      external
+      href="https://smallstep.com/signup?product=cm"
+    >
+      free hosted smallstep Certificate Manager authority
+    </Link>, policies can be configured on the authority, on each provisioner, and on every ACME account, providing more granular control.
+  </div>
+</Alert>
+
+### Examples
+
+Allow all DNS subdomains of `"local"` in X.509 certificates on authority level:
+
+<CodeBlock language="shell-session" copyText="step ca policy authority x509 allow dns '*.local'">
+  {`$ step ca policy authority x509 allow dns "*.local"`}
+</CodeBlock>
+
+Allow IP range `10.0.0.0/24` in X.509 certificates on authority level:
+
+<CodeBlock language="shell-session" copyText="step ca policy authority x509 allow ip 10.0.0.0/24">
+  {`$ step ca policy authority x509 allow ip 10.0.0.0/24`}
+</CodeBlock>
+
+Allow all `devops` principals in SSH user certificates on authority level:
+
+<CodeBlock language="shell-session" copyText="step ca policy authority ssh host allow principal '@devops'">
+  {`$ step ca policy authority ssh user allow email "@devops"`}
+</CodeBlock>
+
+Allow all DNS subdomains of `"local"` in SSH host certificates on authority level:
+
+<CodeBlock language="shell-session" copyText="step ca policy authority ssh host allow dns '*.local'">
+  {`$ step ca policy authority ssh host allow dns "*.local"`}
+</CodeBlock>
+
+You can find more examples in the `step` CLI command reference for the [`step ca policy`](https://smallstep.com/docs/step-cli/reference/ca/policy) namespace.
+
+### Policy in Configuration File
+
+When running a self-hosted `step-ca` it is also possible to configure the authority policy in the `ca.json` CA configuration file.
+It has to be embedded in the `"authority"` object.
+An example is shown below:
+
+```json
+"policy": {
+    "x509":
+        "allow": {
+            "dns": ["*.local"],
+            "ip": ["192.168.0.0/24"]
+        },
+        "deny": {
+            "dns": ["forbidden.local"],
+            "ip": ["192.168.0.1"]
+        },
+        "allowWildcardNames": false,
+    },
+    "ssh": {
+        "user": {
+            "allow": {
+                "email": ["@local"]
+            },
+            "deny": {
+                "email": ["root@local"]
+            }
+        },
+        "host": {
+            "allow": {
+                "dns": ["*.local"],
+                "ip": ["192.168.0.0/24"]
+            },
+            "deny": {
+                "dns": ["forbidden.local"],
+                "ip": ["192.168.0.1"]
+            }
+        }
+    }
+}
+```
+
+It is not required to add rules for every type of certificate.
+If you run a CA intended just for X.509 certificates, you don't need to provide rules for SSH certificates and can omit the corresponding keys.
+

--- a/src/pages/docs/step-ca/policies.mdx
+++ b/src/pages/docs/step-ca/policies.mdx
@@ -50,7 +50,7 @@ A policy for X.509 certificates can have rules for the following types of names:
 
 - Domain Names
 - IP Addresses
-- Email addresses
+- Email Addresses
 - URIs
 - Subject Common Names
 
@@ -61,7 +61,7 @@ The following subsections describe the specifics for each of those.
 Rules for DNS domains are evaluated to match largely according to how [Name Constraints (RFC 5280)](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.10)
 are evaluated, but applied to leaf certificates instead of CA certificates:
 
-- Domain names are normalized into their [internationalized representation (RFC 5890)](https://datatracker.ietf.org/doc/html/rfc5890).
+- Requested domain names as well as the rules for domain names are normalized into their [internationalized representation (RFC 5890)](https://datatracker.ietf.org/doc/html/rfc5890).
 - The domain to be evaluated must have the same number of labels, demarcated by periods, as the rule has.
 - Each domain label is compared using a string comparison.
 
@@ -69,6 +69,9 @@ The rules for domain names allow a wildcard (`*`) to be specified as the first l
 This allows (strictly) the first label to be filled freely.
 For example, the rule `*.example.com` allows any subdomain of `example.com`, such as `www.example.com`.
 It doesn't allow the domain `example.com` itself, though.
+
+A rule for `*.éxàmplê.com` will internally be represented using its internationalized form: `*.xn–xmpl-0na6cm.com`. 
+This rule will match `www.éxàmplê.com` as well as its internationalized representation `www.xn–xmpl-0na6cm.com` (and other subdomains).
 
 By default it is not possible to request a certificate with a literal wildcard character in the domain, like `*.example.com`.
 It is possible to configure the policy to allow this.
@@ -125,11 +128,12 @@ Rules for evaluating URIs are evaluated as follows:
 
 - URI domains are normalized into their [internationalized representation (RFC 5890)](https://datatracker.ietf.org/doc/html/rfc5890).
 - URI rules must contain an authority part and cannot contain IP addresses, in correspondence with [RFC 5280](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.10).
-- URI schemes are not matched. When configuring an URI rule, the scheme is ignored.
 - Matching URI domains is performed by matching URI domain labels, similar as what's done for DNS domains.
 
 Wildcards in URI rules are evaluated similar to wildcards for domain names.
 URIs cannot contain literal wildcards, unlike DNS domains.
+
+☠️ URI schemes are (currently) not matched. When configuring an URI rule, the scheme is ignored. This could lead to certificates being signed with URI schemes you didn't anticipate, so please take note of this if your application or environment relies on the URI scheme.
 
 #### Examples
 
@@ -174,7 +178,6 @@ A policy for SSH host certificates can have rules for the following:
 
 - DNS domains
 - IP ranges and addresses
-- Principals
 
 When an SSH certificate is requested the policy to be evaluated will be based on the certificate type.
 Then the appropriate policy is evaluated for every principal in the certificate.
@@ -204,7 +207,6 @@ principal   |johndoe            |johndoe                                |janedoe
 
 Policies can be administered using the `step` CLI application.
 The commands are part of the [`step ca policy`](https://smallstep.com/docs/step-cli/reference/ca/policy) namespace.
-There are subcommands for administering `authority`, `provisioner` and `acme` policies.
 In a self-hosted `step-ca`, policies can be configured on the authority level.
 
 <Alert severity="info">
@@ -289,6 +291,14 @@ An example is shown below:
     }
 }
 ```
+
+Make `step-ca` reload its configuration by sending it a `SIGHUP`:
+
+```shell
+killall -i -s SIGHUP step-ca
+```
+
+Alternatively, you can restart `step-ca` manually.
 
 It is not required to add rules for every type of certificate.
 If you run a CA intended just for X.509 certificates, you don't need to provide rules for SSH certificates and can omit the corresponding keys.

--- a/src/pages/docs/step-ca/policies.mdx
+++ b/src/pages/docs/step-ca/policies.mdx
@@ -1,0 +1,205 @@
+---
+title: Certificate Issuance Policies
+html_title: Certificate Issuance Policies
+description: Certificate issuance policies can be used to allow or deny certificates to be signed based on the requested names.
+---
+
+Administrators can create a certificate issuance policy to configure which certificate names the CA is allowed to sign.
+A policy consists of one or more rules that are all evaluated just before a new certificate is signed.
+Upon evaluation of the rules all names in a certificate request are checked to be allowed.
+If one of the names is not allowed, the certificate will not be signed.
+An error will be reported to the client indicating why the certificate wasn't created.
+
+You can configure a policy for X.509 certificates, SSH user certificates and SSH host certificates.
+The CA will evaluate only the policy corresponding to the type of certificate that is requested.
+This means that rules for X.509 certificates will not be evaluated when an SSH user or host certificate is requested.
+
+<Alert severity="info">
+  <AlertTitle>Need more control?</AlertTitle>
+  <div>
+    A self-hosted <Code>step-ca</Code> instance can only be configured with a policy on the authority level.
+    In a <Link
+      external
+      href="https://smallstep.com/signup?product=cm"
+    >
+      free hosted smallstep Certificate Manager authority
+    </Link>, policies can be configured on the authority, on each provisioner, and on every ACME account.
+  </div>
+</Alert>
+
+## Policy Evaluation
+
+Policies consist of one or more rules, each resulting in a (range of) names to be allowed or denied.
+A rule is applied to a single name type, like X.509 DNS domains or IP addresses.
+You'll need to configure multiple rules if you want the policy to apply to multiple types of names.
+
+If a rule is configured to allow a certain type of name, all other types of names are automatically denied.
+If a rule is configured to deny a certain type of name, all other types of names are still allowed.
+Generally a policy will contain a set of allowed names and can contain a number of exclusions.
+
+A rule can be configured to allow a range of names using a wildcard notation corresponding to the type of name.
+Another rule can be configured that denies a subset of the allowed range of names.
+Creating the opposite set of rules, denying a certain range and allowing a subset of that range, however, will not result in the names to be allowed. 
+
+The semantics used for evaluating rules and matching requested certificate names is described in the following sections.
+
+
+## X.509 Policies
+
+A policy for X.509 certificates can have rules for the following types of names:
+
+- Domain Names
+- IP Addresses
+- Email addresses
+- URIs
+- Subject Common Names
+
+The following subsections describe the specifics for each of those.
+
+### Domain Names
+
+Rules for DNS domains are evaluated to match largely according to how [Name Constraints (RFC 5280)](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.10)
+are evaluated, but applied to leaf certificates instead of CA certificates:
+
+- Domain names are normalized into their [internationalized representation (RFC 5890)](https://datatracker.ietf.org/doc/html/rfc5890).
+- The domain to be evaluated must have the same number of labels, demarcated by periods, as the rule has.
+- Each domain label is compared using a string comparison.
+
+The rules for domain names allow a wildcard (`*`) to be specified as the first label.
+This allows (strictly) the first label to be filled freely.
+For example, the rule `*.example.com` allows any subdomain of `example.com`, such as `www.example.com`.
+It doesn't allow the domain `example.com` itself, though.
+
+By default it is not possible to request a certificate with a literal wildcard character in the domain, like `*.example.com`.
+It is possible to configure the policy to allow this.
+
+#### Examples
+
+Type    | Rule              | Matches                               | Non-Matches
+--------|:-:                |:-:                                    |:-:
+dns     |host.example.com   |host.example.com                       |differenthost.example.com, sub.host.example.com
+dns     |*.example.com      |host.example.com, www.example.com      |example.com, sub.host.example.com
+
+
+### IP Addresses 
+
+Rules for evaluating IP addresses are evaluated as follows:
+
+- A single IP rule (e.g. `192.168.0.30`, `::1`) will match exactly that IP address.
+- A CIDR rule (e.g. `192.168.0.0/24`, `2001:0db8:85a3::8a2e:0370:7334/120`) matches all IP addresses included in the range.
+- So-called `IPv4-in-IPv6` addresses will be matched using rules for either IPv6 or IPv4. This is because Go doesn't distinguish these.
+
+#### Examples
+
+Type    | Rule                              | Matches                       | Non-Matches
+--------|:-:                                |:-:                            |:-:
+ip      |192.168.0.1                        |192.168.0.1                    |192.168.0.30, 10.0.0.1
+ip      |192.168.0.0/24                     |192.168.0.1, 192.168.0.10      |192.168.20.1, 10.0.0.1
+ip      |::1                                |::1                            |::2
+ip      |2001:0db8:85a3::8a2e:0370:7334/120 |2001:0db8:85a3::8a2e:0370:7334 |3001:0db8:85a3::8a2e:0370:7334
+
+
+### Email Addresses 
+
+Rules for evaluating email addresses are evaluated as follows:
+
+- Email domain names are normalized into their [internationalized representation (RFC 5890)](https://datatracker.ietf.org/doc/html/rfc5890).
+- A specific email address (e.g. `jdoe@example.com`) will match exactly that email address.
+- A rule without a specific local part (e.g. `@example.com`) will match any email address ending in `@example.com`.
+
+It is not possible to configure a wildcard subdomain.
+You'll need to configure multiple email rules in case you need to match email addresses using different subdomains.
+
+#### Examples
+
+Type        | Rule                      | Matches                                   | Non-Matches
+------------|:-:                        |:-:                                        |:-:
+email       |jdoe@example.com           |jdoe@example.com                           |janedoe@example.com
+email       |@example.com               |jdoe@example.com, janedoe@example.com      |jdoe@www.example.com, jdoe@somehost.com
+
+
+
+### URIs
+
+Rules for evaluating URIs are evaluated as follows:
+
+- URI domains are normalized into their [internationalized representation (RFC 5890)](https://datatracker.ietf.org/doc/html/rfc5890).
+- URI rules must contain an authority part and cannot contain IP addresses, in correspondence with [RFC 5280](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.10).
+- URI schemes are not matched. When configuring an URI rule, the scheme is ignored.
+- Matching URI domains is performed by matching URI domain labels, similar as what's done for DNS domains.
+
+Wildcards in URI rules are evaluated similar to wildcards for domain names.
+URIs cannot contain literal wildcards, unlike DNS domains.
+
+#### Examples
+
+Type        | Rule                      | Matches                                           | Non-Matches
+------------|:-:                        |:-:                                                |:-:
+uri         |https://host.example.com   |https://host.example.com,sftps://host.example.com  |https://www.example.com
+uri         |https://*.example.com      |https://host.example.com,https://www.example.com   |https://example.com, https://somehost.com
+uri         |*.example.com              |https://host.example.com,https://www.example.com   |https://example.com, https://somehost.com
+
+
+
+### Subject Common Name
+
+The Subject Common Name is a bit of a special case.
+When no rules are configured specifically for the Common Name, the Common Name in an X.509 certificate will be evaluated against the rules and evaluation logic for the other name types, according to what type it is.
+For example, if the Common Name has a value of `www.example.com`, it will be evaluated against the rules for DNS domains.
+
+Type    | Rule              | Matches           | Non-Matches
+--------|:-:                |:-:                |:-:
+dns     |*.local            |ca.local           |ca.example.com
+ip      |192.168.0.0/24     |192.168.0.1        |10.0.0.1
+email   |@local             |ca@local           |ca@example.com
+uri     |https://*.local    |https://ca.local   |https://ca.example.com
+
+Not every Common Name is a valid DNS domain, IP, email address or URI, however, so that's why it's also possible to provide rules specifically for Common Names.
+Rules for Common Names are evaluated using a strict string comparison.
+
+Type    | Rule              | Matches                               | Non-Matches
+--------|:-:                |:-:                                    |:-:
+cn      |Custom CA Name     |Custom CA Name                         |Different CA Name
+
+
+## SSH Policies
+
+Policies for SSH certificates consist of rules for user and host certificates.
+A policy for SSH user certificates can have rules for the following:
+
+- Email address domains
+- Principals
+
+A policy for SSH host certificates can have rules for the following:
+
+- DNS domains
+- IP ranges and addresses
+- Principals
+
+When an SSH certificate is requested the policy to be evaluated will be based on the certificate type.
+Then the appropriate policy is evaluated for every principal in the certificate.
+
+For SSH host certificates, every principal is matched against `dns` or `ip` rules.
+Evaluation of the `dns` and `ip` rules is the same as for X.509 certificates.
+
+For SSH user certificates, every principal is parsed to check if it's a valid email address and will then be matched against `email` rules.
+Evaluation of `email` rules is performed like those for X.509 certificates.
+If a principal is not a valid email address, it will be matched against `principal` rules.
+Principals are matched using a strict string comparison and it is possible to configure a wildcard to allow any principal name.
+
+If a policy has rules for user certificates and no rule for host certificates, host certificates will be denied.
+The same is true in case there are rules for host certificates and none for user certificates: a user certificate will then always be denied.
+
+
+Type        | Rule              | Matches                               | Non-Matches
+------------|:-:                |:-:                                    |:-:
+dns         |*.local            |host.local                             |host.example.com
+ip          |192.168.0.0/24     |192.168.0.1                            |10.0.0.1
+email       |@devops            |jane@devops                            |john@finance  
+principal   |*                  |johndoe, john, janedoe, jane           |
+principal   |johndoe            |johndoe                                |janedoe                
+
+
+## Policy Configuration
+
+TODO: using CLI; using ca.json

--- a/src/pages/docs/step-ca/policies.mdx
+++ b/src/pages/docs/step-ca/policies.mdx
@@ -43,6 +43,25 @@ Creating the opposite set of rules, denying a certain range and allowing a subse
 
 The semantics used for evaluating rules and matching requested certificate names is described in the following sections.
 
+<Alert severity="info">
+  <AlertTitle>Certificate Issuance Policy vs. Name Constraints</AlertTitle>
+  <div>
+    This page describes how certificate issuance policies work in the smallstep platform.
+    These policies must not be confused with <Link
+        external
+        href="https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.10"
+      >
+      X.509 Name Constraints (RFC 5280)
+    </Link>, which work slightly different.
+  </div>
+  <br/>
+  <div>
+      When Name Constraints are in use, clients must verify that a leaf certificate was allowed to be signed by the CA.
+    A certificate issuance policy is evaluated by the CA before a certificate is signed instead, shifting control and responsibility to the CA.
+    Certificate issuance policies and Name Constraints are not mutually exclusive: they can be combined and used simultaneously.
+  </div>
+</Alert>
+
 
 ## X.509 Policies
 


### PR DESCRIPTION
Add docs for certificate issuance policy

High level policy description, rules per name type, some example rules, configuration using `ca.json` and CLI and a couple of CTAs for more granular control in CM/SSH.

P.S.: also did a little trial with creating a `wasm` build of the policy engine (imported as a library) and that seems to work out of the box. That would open up dynamic docs or an interactive form where people can try a policy more easily, while still using the exact same logic as performed by the CA! 😃  
