### PR TITLE
Add description and layout to Algolia

### DIFF
--- a/src/algolia-queries.js
+++ b/src/algolia-queries.js
@@ -15,6 +15,8 @@ const pageQuery = `{
         id
         frontmatter {
           title
+		  description
+		  layout
         }
         excerpt(pruneLength: 8000)
         slug

--- a/src/algolia-queries.js
+++ b/src/algolia-queries.js
@@ -16,7 +16,7 @@ const pageQuery = `{
         frontmatter {
           title
 		  description
-		  layout
+		  category
         }
         excerpt(pruneLength: 8000)
         slug


### PR DESCRIPTION
Here's a PR that adds the `description` and `category` from MDX frontmatter to Algolia.

The `category` can be used to lower the priority of "reference" pages, and boost the main doc pages.
See also: smallstep/cli#734

I don't have a great application for the `description` field, but it could be good to have the option to show it in the search results.
