### PR TITLE
Correct provisioner name

### DIFF
--- a/src/pages/docs/step-ca/provisioners.mdx
+++ b/src/pages/docs/step-ca/provisioners.mdx
@@ -1232,7 +1232,7 @@ The CA will validate the JWT and grant a certificate.
 
 #### Example
 
-On the host running `step-ca`, add an GCP provisioner to your configuration by running:
+On the host running `step-ca`, add an Azure provisioner to your configuration by running:
 
 ```shell
 step ca provisioner add Azure --type Azure \


### PR DESCRIPTION
GCP is mentioned incorrectly in Azure instructions.