### PR TITLE
Correct dead links to the "ACME Basics" page

### DIFF
--- a/src/pages/docs/step-ca/provisioners.mdx
+++ b/src/pages/docs/step-ca/provisioners.mdx
@@ -862,7 +862,7 @@ see the [claims](#claims) section for all the options.
 
 <br /><br />
 
-See [ACME Basics](/docs/tutorials/acme-basics)
+See [ACME Basics](/docs/step-ca/acme-basics)
 for more guidance on configuring and using the ACME protocol with `step-ca`.
 
 ### SCEP

--- a/src/pages/docs/tutorials/kubernetes-acme-ca.mdx
+++ b/src/pages/docs/tutorials/kubernetes-acme-ca.mdx
@@ -20,7 +20,7 @@ using cert-manager's [ACME issuer](https://cert-manager.io/docs/configuration/ac
 
 ## Requirements
 
-- **Open source -** You have initialized and started up a `step-ca` ACME instance using the steps in [our ACME server tutorial](/docs/tutorials/acme-basics).
+- **Open source -** You have initialized and started up a `step-ca` ACME instance using the steps in [our ACME server tutorial](/docs/step-ca/acme-basics).
 - **[Smallstep Certificate Manager](https://smallstep.com/certificate-manager) -** this tutorial assumes you have [created a hosted or linked authority](/docs/certificate-manager/getting-started) and are running a local [ACME Registration Authority](/docs/registration-authorities/acme-for-certificate-manager). 
 - You'll need the root certificate PEM file for your CA.
 


### PR DESCRIPTION
Looks like the page was moved in 91d40fa