### PR TITLE
Fix the short policy example

### DIFF
--- a/src/pages/docs/step-ca/configuration.mdx
+++ b/src/pages/docs/step-ca/configuration.mdx
@@ -103,14 +103,20 @@ CA's keys.
       "defaultUserSSHCertDuration": "16h",
       "policy": {
         "x509": {
-          "allow": ["*.local"]
+          "allow": {
+            "dns": ["*.local"]
+          }
         },
         "ssh": {
           "user": {
-            "allow": ["@local"]
+            "allow": {
+              "email": ["@local"]
+            }
           },
           "host": {
-            "allow": ["*.local"]
+            "allow": {
+              "dns": ["*.local"]
+            }
           }
         }
       }


### PR DESCRIPTION
This was reported in https://github.com/smallstep/certificates/issues/1181. The compact example was missing `dns` and `email` labels.