### PR TITLE
Add certificate duration to traefik config

### DIFF
--- a/src/pages/docs/tutorials/acme-protocol-acme-clients.mdx
+++ b/src/pages/docs/tutorials/acme-protocol-acme-clients.mdx
@@ -554,6 +554,7 @@ In your Traefik static configuration, you'll need to add a `certificatesResolver
       caServer = "https://step-ca.internal/acme/acme/directory"
       email = "carl@smallstep.com"
       storage = "acme.json"
+      certificatesDuration = 24
       tlsChallenge = true
 ```
 


### PR DESCRIPTION
As stated in the section about [renewal period](https://smallstep.com/docs/tutorials/acme-protocol-acme-clients#renewal-period), one must set the correct valid time so traefik can correctly renew certificates automatically. Adding the correct setting may save a lot of debug time.

#### Name of feature:
Traefik ACME config

#### Pain or issue this feature alleviates:
by default, Traefik assumes certificate validity for 90 days and does not correctly renew certificates from step-ca with default config.

#### Is there documentation on how to use this feature? If so, where?
https://doc.traefik.io/traefik/https/acme/#certificatesduration

#### In what environments or workflows is this feature supported?
Deployment with Traefik reverse proxy.
