### PR TITLE
Update RA  doc to correct reference to CA password

### DIFF
--- a/src/pages/docs/step-ca/registration-authority-ra-mode.mdx
+++ b/src/pages/docs/step-ca/registration-authority-ra-mode.mdx
@@ -143,7 +143,25 @@ you can create a new key for your RA by decrypting the CA's JWK provisioner key 
   }
   ```
 
-Finally, use `--issuer-password-file` to provide a password file when starting up the CA.
+Finally, use `--issuer-password-file` to provide a password file when starting up the RA. Note that, if using the open source Certificate Manager docker image, you will have to override the default `entrypoint.sh` to pass the appropriate flags. An example using docker compose, assuming the password file is located at `secrets/password`:
+
+```yaml
+services:
+  step-ra:
+    image: smallstep/step-ca
+    command:
+      - "/usr/local/bin/step-ca"
+      - "--issuer-password-file=/home/step/secrets/password"
+      - "/home/step/config/ca.json"
+    depends_on:
+      - ca
+    volumes:
+      - ./:/home/step
+    environment:
+      - STEPDEBUG=1
+    ports:
+      - "8484:8484/tcp"  
+```
 
 ### Using the X5C provisioner
 
@@ -170,7 +188,7 @@ Next, change the `"certificateIssuer"` object in the RA configuration as follows
 
 These files will are read by `step-ca` upon every certificate request made to the RA.
 
-Finally, use `--issuer-password-file` to provide a private key password file when starting up the CA.
+Finally, use `--issuer-password-file` to provide a private key password file when starting up the RA.
 
 ### StepCAS Limitations
 


### PR DESCRIPTION
<!---
Please provide answers in the spaces below each prompt, where applicable.
Not every PR requires responses for each prompt.
Use your discretion.
-->
#### Name of feature:

Documentation update

#### Pain or issue this feature alleviates:

The previous version incorrectly stated that `--issuer-password-file` was against the CA. It is against the RA. Additionally, a small `docker-compose.yml` extract is provided as an example of how to achieve this using the `step-ca` docker image

#### Why is this important to the project (if not answered above):

#### Is there documentation on how to use this feature? If so, where?
No, there is no documentation on the documentation. Curses!

#### In what environments or workflows is this feature supported?

#### In what environments or workflows is this feature explicitly NOT supported (if any)?

#### Supporting links/other PRs/issues:

💔Thank you!
