### PR TITLE
Fix docs

### DIFF
--- a/src/pages/docs/step-ca/installation.mdx
+++ b/src/pages/docs/step-ca/installation.mdx
@@ -22,6 +22,7 @@ It's trivial to install the `step-ca` binary on your local machine.
 - [Linux Packages](#linux-packages-amd64)
   - [Debian](#debian)   
   - [Arch Linux](#arch-linux)
+  - [RedHat](#redhat)
   - [Alpine Linux](#alpine-linux)
   - [NixOS](#nixos)
   - [FreeBSD](#freebsd)
@@ -89,6 +90,30 @@ The binary tarballs can be found here:
 Big shout out to the maintainers of these packages! We appreciate you.
 
 To uninstall, run `pacman -R step-ca step-cli` and remove the configuration directory `$HOME/.step`.
+
+#### RedHat
+
+1. Install `step`
+
+    Download and install the RPM package for your platform from our [latest release](https://github.com/smallstep/cli/releases/latest):
+    
+    ```shell
+    wget https://dl.step.sm/gh-release/cli/docs-ca-install/v0.21.0/step-cli_0.21.0_amd64.rpm
+    sudo rpm -i step-cli_0.21.0_amd64.rpm
+    ```
+
+2. Install `step-ca`
+
+    Download and install the RPM package for your platform from our [latest release](https://github.com/smallstep/certificates/releases/latest):
+
+    ```shell
+    wget https://dl.step.sm/gh-release/certificates/docs-ca-install/v0.21.0/step-ca_0.21.0_amd64.deb
+    sudo rpm -i step-ca_0.21.0_amd64.deb
+    ```
+To configure `step-ca` as a daemon, see our [systemd configuration guide][systemd-setup].
+
+To uninstall, run `dnf remove step-cli step-ca` and remove the configuration directory `$HOME/.step`.
+
 
 #### Alpine Linux
 
@@ -208,3 +233,4 @@ Release Date: 2019-04-30 19:02 UTC
 
 - Learn about the [core concepts and design principles](/docs/step-ca/certificate-authority-core-concepts) behind `step-ca`.
 - Read the [Getting Started guide](/docs/step-ca/getting-started) to set up a CA and get your first certificate.
+

--- a/src/pages/docs/step-ca/installation.mdx
+++ b/src/pages/docs/step-ca/installation.mdx
@@ -56,8 +56,8 @@ brew install step
     Download and install the Debian package for your platform from our [latest release](https://github.com/smallstep/cli/releases/latest):
     
     ```shell
-    wget https://dl.step.sm/gh-release/cli/docs-ca-install/v0.21.0/step-cli_0.21.0_amd64.deb
-    sudo dpkg -i step-cli_0.21.0_amd64.deb
+    wget https://dl.step.sm/gh-release/cli/docs-ca-install/v0.23.1/step-cli_0.23.1_amd64.deb
+    sudo dpkg -i step-cli_0.23.1_amd64.deb
     ```
 
 2. Install `step-ca`
@@ -65,8 +65,8 @@ brew install step
     Download and install the Debian package for your platform from our [latest release](https://github.com/smallstep/certificates/releases/latest):
 
     ```shell
-    wget https://dl.step.sm/gh-release/certificates/docs-ca-install/v0.21.0/step-ca_0.21.0_amd64.deb
-    sudo dpkg -i step-ca_0.21.0_amd64.deb
+    wget https://dl.step.sm/gh-release/certificates/docs-ca-install/v0.23.1/step-ca_0.23.1_amd64.deb
+    sudo dpkg -i step-ca_0.23.1_amd64.deb
     ```
 
 To configure `step-ca` as a daemon, see our [systemd configuration guide][systemd-setup].
@@ -98,8 +98,8 @@ To uninstall, run `pacman -R step-ca step-cli` and remove the configuration dire
     Download and install the RPM package for your platform from our [latest release](https://github.com/smallstep/cli/releases/latest):
     
     ```shell
-    wget https://dl.step.sm/gh-release/cli/docs-ca-install/v0.21.0/step-cli_0.21.0_amd64.rpm
-    sudo rpm -i step-cli_0.21.0_amd64.rpm
+    wget https://dl.step.sm/gh-release/cli/docs-ca-install/v0.23.1/step-cli_0.23.1_amd64.rpm
+    sudo rpm -i step-cli_0.23.1_amd64.rpm
     ```
 
 2. Install `step-ca`
@@ -107,8 +107,8 @@ To uninstall, run `pacman -R step-ca step-cli` and remove the configuration dire
     Download and install the RPM package for your platform from our [latest release](https://github.com/smallstep/certificates/releases/latest):
 
     ```shell
-    wget https://dl.step.sm/gh-release/certificates/docs-ca-install/v0.21.0/step-ca_0.21.0_amd64.deb
-    sudo rpm -i step-ca_0.21.0_amd64.deb
+    wget https://dl.step.sm/gh-release/certificates/docs-ca-install/v0.23.1/step-ca_0.23.1_amd64.deb
+    sudo rpm -i step-ca_0.23.1_amd64.deb
     ```
 To configure `step-ca` as a daemon, see our [systemd configuration guide][systemd-setup].
 
@@ -171,9 +171,9 @@ Here's how to download and install the `step` and `step-ca` binaries on an amd64
     Download and install the Linux tarball from our [latest release](https://github.com/smallstep/cli/releases/latest):
 
     ```shell
-    wget -O step.tar.gz https://dl.step.sm/gh-release/cli/docs-ca-install/v0.21.0/step_linux_0.21.0_amd64.tar.gz
+    wget -O step.tar.gz https://dl.step.sm/gh-release/cli/docs-ca-install/v0.23.1/step_linux_0.23.1_amd64.tar.gz
     tar -xf step.tar.gz
-    sudo cp step_0.21.0/bin/step /usr/bin
+    sudo cp step_0.23.1/bin/step /usr/bin
     ```
 
 2. Install `step-ca`
@@ -181,9 +181,9 @@ Here's how to download and install the `step` and `step-ca` binaries on an amd64
     Download and install the Linux tarball from our [latest release](https://github.com/smallstep/certificates/releases/latest):
 
     ```shell
-    wget -O step-ca.tar.gz https://dl.step.sm/gh-release/certificates/docs-ca-install/v0.21.0/step-ca_linux_0.21.0_amd64.tar.gz
+    wget -O step-ca.tar.gz https://dl.step.sm/gh-release/certificates/docs-ca-install/v0.23.1/step-ca_linux_0.23.1_amd64.tar.gz
     tar -xf step-ca.tar.gz
-    sudo cp step-ca_0.21.0/bin/step-ca /usr/bin
+    sudo cp step-ca_0.23.1/bin/step-ca /usr/bin
     ```
 
 To configure `step-ca` as a daemon, see our [systemd configuration guide][systemd-setup].

--- a/src/pages/docs/step-cli/installation.mdx
+++ b/src/pages/docs/step-cli/installation.mdx
@@ -54,6 +54,17 @@ To uninstall, run `pacman -R step-cli` and remove the `$HOME/.step` configuratio
 
 Big shout out to the maintainers of these packages! We appreciate you.
 
+#### RedHat
+
+Download and install the RPM package from our [latest release](https://github.com/smallstep/cli/releases/latest):
+
+```shell
+wget https://dl.step.sm/gh-release/cli/docs-ca-install/v0.21.0/step-cli_0.21.0_amd64.rpm
+sudo rpm -i step-cli_0.21.0_amd64.rpm
+```
+
+To uninstall, run `sudo dnf remove step-cli` and remove the `$HOME/.step` configuration directory.
+
 #### Alpine Linux
 
 <Alert severity="info">

--- a/src/pages/docs/step-cli/installation.mdx
+++ b/src/pages/docs/step-cli/installation.mdx
@@ -17,6 +17,20 @@ It's trivial to install the `step` binary on your local machine.
   </div>
 </Alert>
 
+#### Select your operating system or infrastructure:
+
+- [macOS](#macos)
+- [Linux Packages](#linux-packages-amd64)
+  - [Debian](#debian)   
+  - [Arch Linux](#arch-linux)
+  - [RedHat](#redhat)
+  - [Alpine Linux](#alpine-linux)
+  - [NixOS](#nixos)
+  - [FreeBSD](#freebsd)
+- [Linux binaries](#linux-binaries)
+- [Kubernetes](#kubernetes)
+- [Docker](#docker)
+
 ### macOS
 
 Install `step` via [Homebrew](https://brew.sh/):

--- a/src/pages/docs/step-cli/installation.mdx
+++ b/src/pages/docs/step-cli/installation.mdx
@@ -48,8 +48,8 @@ To uninstall, run `brew uninstall step` and remove the `$HOME/.step` configurati
 Download and install the Debian package from our [latest release](https://github.com/smallstep/cli/releases/latest):
 
 ```shell
-wget https://dl.step.sm/gh-release/cli/docs-cli-install/v0.21.0/step-cli_0.21.0_amd64.deb
-sudo dpkg -i step-cli_0.21.0_amd64.deb
+wget https://dl.step.sm/gh-release/cli/docs-cli-install/v0.23.1/step-cli_0.23.1_amd64.deb
+sudo dpkg -i step-cli_0.23.1_amd64.deb
 ```
 
 To uninstall, run `sudo dpkg -r step-cli` and remove the `$HOME/.step` configuration directory.
@@ -73,8 +73,8 @@ Big shout out to the maintainers of these packages! We appreciate you.
 Download and install the RPM package from our [latest release](https://github.com/smallstep/cli/releases/latest):
 
 ```shell
-wget https://dl.step.sm/gh-release/cli/docs-ca-install/v0.21.0/step-cli_0.21.0_amd64.rpm
-sudo rpm -i step-cli_0.21.0_amd64.rpm
+wget https://dl.step.sm/gh-release/cli/docs-ca-install/v0.23.1/step-cli_0.23.1_amd64.rpm
+sudo rpm -i step-cli_0.23.1_amd64.rpm
 ```
 
 To uninstall, run `sudo dnf remove step-cli` and remove the `$HOME/.step` configuration directory.
@@ -138,9 +138,9 @@ Download the Windows binary from our [latest releases](https://github.com/smalls
 Open PowerShell and run the following:
 
 ```shell
-curl.exe -LO https://dl.step.sm/gh-release/cli/docs-cli-install/v0.21.0/step_windows_0.21.0_amd64.zip
-Expand-Archive -LiteralPath .\step_windows_0.21.0_amd64.zip -DestinationPath .
-step_0.21.0\bin\step.exe version
+curl.exe -LO https://dl.step.sm/gh-release/cli/docs-cli-install/v0.23.1/step_windows_0.23.1_amd64.zip
+Expand-Archive -LiteralPath .\step_windows_0.23.1_amd64.zip -DestinationPath .
+step_0.23.1\bin\step.exe version
 ```
 
 Finally, move the `step.exe` binary wherever you'd like it to into a location in your user's `PATH`.


### PR DESCRIPTION
<!---
Please provide answers in the spaces below each prompt, where applicable.
Not every PR requires responses for each prompt.
Use your discretion.
-->
#### Name of feature:

#### Pain or issue this feature alleviates:
Make it easier for users to find how to install step-ca and step-cli and the links for these rpms

#### Why is this important to the project (if not answered above):
Being clear that it is possible to also install on RPM based systems will broader the audience

#### Is there documentation on how to use this feature? If so, where?
Yes, in this PR

#### In what environments or workflows is this feature supported?

#### In what environments or workflows is this feature explicitly NOT supported (if any)?

#### Supporting links/other PRs/issues:

💔Thank you!
