### PR TITLE
Update policies.mdx

### DIFF
--- a/src/pages/docs/step-ca/policies.mdx
+++ b/src/pages/docs/step-ca/policies.mdx
@@ -302,7 +302,7 @@ An example is shown below:
 
 ```json
 "policy": {
-    "x509":
+    "x509": {
         "allow": {
             "dns": ["*.local"],
             "ip": ["192.168.0.0/24"]


### PR DESCRIPTION
Missing '{' after x509 definition block

Or at least, it seems a formatting error :) , let me know if I am wrong! 
