### PR TITLE
feat: add upload-asset workflow

### DIFF
--- a/.github/workflows/upload-assets.yml
+++ b/.github/workflows/upload-assets.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - 'main'
     paths:
-      - 'docs/assets/**'
+      - 'graphics/**'
 
 jobs:
   upload:

--- a/.github/workflows/upload-assets.yml
+++ b/.github/workflows/upload-assets.yml
@@ -1,0 +1,23 @@
+name: Upload Assets
+
+on:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - 'docs/assets/**'
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Upload to S3
+        uses: shallwefootball/upload-s3-action@v1.3.3
+        id: S3
+        with:
+          aws_key_id: ${{ secrets.AWS_ASSETS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.AWS_ASSETS_SECRET_ACCESS_KEY}}
+          aws_bucket: ${{ secrets.AWS_ASSETS_BUCKET }}
+          source_dir: 'graphics'
+          destination_dir: 'graphics'


### PR DESCRIPTION
@tashian this requires the following three repository secrets to be set:

- `AWS_ASSETS_KEY_ID`
- `AWS_ASSETS_SECRET_ACCESS_KEY`
- `AWS_ASSETS_BUCKET`

The workflow will trigger on any change in the `/graphics` folder and upload/overwrite assets on S3