### PR TITLE
Update relative links

### DIFF
--- a/ssh/hosts.mdx
+++ b/ssh/hosts.mdx
@@ -130,7 +130,7 @@ You should see your host listed under the "**Hosts**" tab.
 ## Manual Instructions
 
 If you wish to enroll your host without using our script,
-you can follow our [step-by-step installation instructions](../ssh/hosts-step-by-step.mdx) instead.
+you can follow our [step-by-step installation instructions](./hosts-step-by-step.mdx) instead.
 
 ## Need to remove a host?
 

--- a/ssh/how-it-works.mdx
+++ b/ssh/how-it-works.mdx
@@ -50,7 +50,7 @@ With an SSH certificate in place, smallstep interacts with SSHD, PAM, and NSS UN
 
 Host tags are similar to EC2 Instance Tags. They’re used to define collections of hosts for access control. You might assign tags identifying a host’s role (e.g., bastion, web, database), region (e.g., us-east), environment (e.g., staging, production), or any other relevant attribute. Let's look at an example:
 
-![](/graphics/acl-tag-example.png 'Host tags example')
+![image](/graphics/quickstart/host-tags-example.png 'Host tags example')
 
 - A host tag combination of `db`: `dev` gives you access to `myserver #1`.
 - A host tag combination of `db`: `prod` gives you access to `myserver #2` and `myserver #3`.

--- a/ssh/okta.mdx
+++ b/ssh/okta.mdx
@@ -170,7 +170,7 @@ Sign in at `https://smallstep.com/app/[Team ID]`
 
 * Initial activation of Okta OIDC provisioning in Smallstep SSH requires entering your **Client ID, Client Secret**, and **base domain of your Okta instance.** Contact smallstep support with any questions | [support@smallstep.com](mailto:support@smallstep.com)
 * UIDs and GIDs. By default, Smallstep will auto-assign POSIX UIDs and GIDs for your users. Alternatively, you can sync POSIX UIDs and GIDs values from your Okta directory to Smallstep.
-  * See our guide [How to sync UIDs and GIDs from Okta](../ssh/okta-gid-uid.mdx).
+  * See our guide [How to sync UIDs and GIDs from Okta](./okta-gid-uid.mdx).
 * If you are having trouble synchronizing users or groups, it's always recommended to resynchronize the information manually:
   * Applications  → Smallstep → Push Groups → Find Group → "Push Now'
 

--- a/step-ca/README.mdx
+++ b/step-ca/README.mdx
@@ -47,7 +47,7 @@ With `step-ca`, you can:
 - Choose key types (RSA, ECDSA, EdDSA) and lifetimes to suit your needs
 - Issue [short-lived certificates](https://smallstep.com/blog/passive-revocation.html) with automated enrollment, renewal, and passive revocation
 - Operate [an online intermediate CA](https://smallstep.com/docs/tutorials/intermediate-ca-new-ca) to an existing root CA, eg. to add support for ACME to an existing PKI
-- Operate a local [Registration Authority (RA)](../step-ca/registration-authority-ra-mode.mdx) on an internal network or inside a Kubernetes cluster, that authorizes certificate requests for an upstream `step-ca` server.
+- Operate a local [Registration Authority (RA)](./registration-authority-ra-mode.mdx) on an internal network or inside a Kubernetes cluster, that authorizes certificate requests for an upstream `step-ca` server.
 - Deploy a high availability (HA) Certificate Authority using [root federation](https://smallstep.com/blog/step-v0.8.3-federation-root-rotation.html) and/or multiple intermediaries
 
 
@@ -71,11 +71,11 @@ For example, you can have your CA issue certificates in exchange for:
   - ID tokens from Okta, G Suite, Azure AD, Auth0.
   - ID tokens from an OAuth OIDC service that you host, like [Keycloak](https://www.keycloak.org/) or [Dex](https://github.com/dexidp/dex)
 - [Cloud instance identity documents](https://smallstep.com/blog/embarrassingly-easy-certificates-on-aws-azure-gcp/), for VMs on AWS, GCP, and Azure
-- [Single-use, short-lived JWK tokens](../step-ca/provisioners.mdx#jwk), eg. issued by your CD tool — Puppet, Chef, Ansible, Terraform, etc.
+- [Single-use, short-lived JWK tokens](./provisioners.mdx#jwk), eg. issued by your CD tool — Puppet, Chef, Ansible, Terraform, etc.
 
 ### Templates
 
-[X.509 Templates](../step-ca/templates.mdx#x509-templates) let you customize certificate fields, eg:
+[X.509 Templates](./templates.mdx#x509-templates) let you customize certificate fields, eg:
 - Add custom Subject Alternative Names (SANs) or non-standard X.509 Object Identifiers (OIDs) to certificates
 - Restrict certificates by domain name or key size
 - Issue CA certificates with longer path lengths for multiple intermediaries
@@ -85,8 +85,8 @@ and you can use Golang's `text/template` syntax to create new templates.
 
 ### Cryptographic Protection
 
-For strong protection of your CA signing keys, we've built [`step-ca` integrations](../step-ca/configuration.mdx#cryptographic-protection) for PKCS #11 HSMs, Google Cloud KMS, AWS KMS, and YubiKey PIV, among others.
+For strong protection of your CA signing keys, we've built [`step-ca` integrations](./configuration.mdx#cryptographic-protection) for PKCS #11 HSMs, Google Cloud KMS, AWS KMS, and YubiKey PIV, among others.
 
 ### Other Integrations
 
-`step-ca` plays well with Kubernetes cert-manager and Envoy Secret Discovery Service. See [Integrations](../step-ca/integrations.mdx) to learn more.
+`step-ca` plays well with Kubernetes cert-manager and Envoy Secret Discovery Service. See [Integrations](./integrations.mdx) to learn more.

--- a/step-ca/acme-basics.mdx
+++ b/step-ca/acme-basics.mdx
@@ -25,7 +25,7 @@ ACME is a modern, standardized protocol for automatic validation and issuance of
 
 ## Requirements
 
-- **Open source -** This tutorial assumes you have initialized and started up a `step-ca` server (see [Getting Started](../step-ca/getting-started.mdx)).
+- **Open source -** This tutorial assumes you have initialized and started up a `step-ca` server (see [Getting Started](./getting-started.mdx)).
 - **[Smallstep Certificate Manager](https://smallstep.com/certificate-manager) -** follow the instructions provided in the Certificate Manager [ACME documentation](../certificate-manager/acme.mdx).
 
 ## Overview
@@ -117,7 +117,7 @@ These are typically client certificates that can be used for device authenticati
 
 Let's get an X.509 certificate via the ACME `http-01` challenge, using `step-ca`.
 
-First, [add an ACME provisioner](../step-ca/provisioners.mdx#acme) to your `step-ca` configuration to enable ACME support:
+First, [add an ACME provisioner](./provisioners.mdx#acme) to your `step-ca` configuration to enable ACME support:
 
 ```shell
 step ca provisioner add acme --type ACME
@@ -146,5 +146,5 @@ Finalizing Order .. done!
 
 ## Next Steps
 
-- Start tailoring `step-ca` to your infrastructure. See [Provisioners](../step-ca/provisioners.mdx), [Production Considerations](../step-ca/certificate-authority-server-production.mdx), and our [Configuration Guide](../step-ca/configuration.mdx).
+- Start tailoring `step-ca` to your infrastructure. See [Provisioners](./provisioners.mdx), [Production Considerations](./certificate-authority-server-production.mdx), and our [Configuration Guide](./configuration.mdx).
 - Tutorial: Learn [how to configure the most popular ACME clients](../tutorials/acme-protocol-acme-clients.mdx) to connect to a `step-ca` server.

--- a/step-ca/basic-certificate-authority-operations.mdx
+++ b/step-ca/basic-certificate-authority-operations.mdx
@@ -7,7 +7,7 @@ description: Learn about the basic certificate authority operations of step-ca
 
 ## Before You Begin
 
-This document assumes you have initialized and started up a `step-ca` instance using the steps in [Getting Started](../step-ca/getting-started.mdx).
+This document assumes you have initialized and started up a `step-ca` instance using the steps in [Getting Started](./getting-started.mdx).
 
 ## Table of Contents
 
@@ -100,7 +100,7 @@ and inject the token into a Docker container.
 This way, the container can create its own private key and get a certificate,
 but it doesn't hold any long-lived CA credentials.
 
-Under the hood, many of `step-ca`'s [certificate provisioners](../step-ca/certificate-authority-core-concepts.mdx#provisioners) accept a Javascript Web Token (JWT) along with a CSR to authenticate certificate requests:
+Under the hood, many of `step-ca`'s [certificate provisioners](./certificate-authority-core-concepts.mdx#provisioners) accept a Javascript Web Token (JWT) along with a CSR to authenticate certificate requests:
 - The JWK provisioner accepts JWTs signed using a JavaScript Web Key whose public key is configured in the CA.
 - The OIDC provisioner accepts JWTs signed by an identity provider via a single sign-on flow.
 - The X5C provisioner accepts JWTs signed using an X509 certificate private key whose root is configured in the CA.
@@ -171,7 +171,7 @@ $ step ca renew foo.crt foo.key
 Your certificate has been saved in foo.crt.
 ```
 
-When it comes time to renew your certificate, do not dawdle: Once a certificate expires, the CA will not renew it. To avoid catastrophe, you should [set up automated renewals](../step-ca/renewal.mdx) for any certificate that always needs to be valid. Our automation methods will attempt renewal at around two-thirds of a certificate's lifetime.
+When it comes time to renew your certificate, do not dawdle: Once a certificate expires, the CA will not renew it. To avoid catastrophe, you should [set up automated renewals](./renewal.mdx) for any certificate that always needs to be valid. Our automation methods will attempt renewal at around two-thirds of a certificate's lifetime.
 
 Note that because [`step ca renew`](../step-cli/reference/ca/renew) uses mutual TLS authentication, it can only renew client certificates (certificates that are marked with "Client Authentication" key usage). Any other certificate must be replaced before expiry instead.
 
@@ -204,7 +204,7 @@ Note that default maximum certificate duration is 24 hours. To adjust the global
 ```
 
 You can also set default, minimum, and maximum certificate durations on each provisioner.
-See [Basic Configuration Options](../step-ca/configuration.mdx#basic-configuration-options) for more details.
+See [Basic Configuration Options](./configuration.mdx#basic-configuration-options) for more details.
 
 ### Revoke a Certificate
 
@@ -220,7 +220,7 @@ $ step ca revoke --cert svc.crt --key svc.key
 Certificate with Serial Number 30671613121311574910895916201205874495 has been revoked.
 ```
 
-For more on this topic, read [All About Certificate Revocation](../step-ca/revocation.mdx).
+For more on this topic, read [All About Certificate Revocation](./revocation.mdx).
 
 ## Working With SSH Certificates
 
@@ -246,7 +246,7 @@ When [`step ca init`](../step-cli/reference/ca/init is run with `--ssh`, it crea
 ### Requirements
 
 * You will need a `step-ca` Certificate Authority **with SSH support enabled**. Create one by running [`step ca init --ssh`](../step-cli/reference/ca/init).
-* To see SSH certificates in action, set up a host or VM running SSHD. In this example, our host is running Ubuntu 18.04 LTS, and it [has been configured to access our CA remotely](../step-ca/getting-started.mdx#accessing-step-ca-remotely).
+* To see SSH certificates in action, set up a host or VM running SSHD. In this example, our host is running Ubuntu 18.04 LTS, and it [has been configured to access our CA remotely](./getting-started.mdx#accessing-step-ca-remotely).
 
 ### Getting a host to authenticate users
 
@@ -254,7 +254,7 @@ First let's delegate user authentication to the SSH CA.
 
 #### 1. Get your host to trust your SSH user CA
 
-On your host, once you've [bootstrapped your CA configuration](../step-ca/getting-started.mdx#accessing-step-ca-remotely), run:
+On your host, once you've [bootstrapped your CA configuration](./getting-started.mdx#accessing-step-ca-remotely), run:
 
 ```shell-session
 $ step ssh config --roots > /path/to/ssh_user_key.pub
@@ -410,7 +410,7 @@ You're all done. Now test your SSH connection.
 
 ## Next Steps
 
-* Learn to automate certificate management in your PKI. [ACME Basics](../step-ca/acme-basics.mdx) introduces the ACME protocol for certificate automation, and includes a tutorial for setting it up with `step-ca`.
-* See [Provisioners](../step-ca/provisioners.mdx), [Production Considerations](../step-ca/certificate-authority-server-production.mdx), and our [Configuration Guide](../step-ca/configuration.mdx) to learn more about tailoring `step-ca` to your infrastructure.
+* Learn to automate certificate management in your PKI. [ACME Basics](./acme-basics.mdx) introduces the ACME protocol for certificate automation, and includes a tutorial for setting it up with `step-ca`.
+* See [Provisioners](./provisioners.mdx), [Production Considerations](./certificate-authority-server-production.mdx), and our [Configuration Guide](./configuration.mdx) to learn more about tailoring `step-ca` to your infrastructure.
 * Run [`step ca help`](../step-cli/reference/ca) or [`step ssh help`](../step-cli/reference/ssh) for many more flags and examples.
 * Our [Tutorials](../tutorials) can guide you through more complex scenarios for using `step-ca` in various contexts and workflows.

--- a/step-ca/certificate-authority-core-concepts.mdx
+++ b/step-ca/certificate-authority-core-concepts.mdx
@@ -40,14 +40,14 @@ request](https://smallstep.com/blog/everything-pki.html#certificate-signing-requ
 The details of how a provisioner interacts with an entity (machines or people) and the CA vary by provisioner type.
 Smallstep supports a number of provisioner types including:
 
-- [ACME protocol](../step-ca/provisioners.mdx#acme)
-- [OAuth/OIDC Single Sign-on](../step-ca/provisioners.mdx#oauthoidc-single-sign-on)
-- [AWS Instance Identity Documents](../step-ca/provisioners.mdx#aws)
-- [Google Cloud Instance Identity Tokens](../step-ca/provisioners.mdx#gcp)
-- [Azure Instance Metadata Service](../step-ca/provisioners.mdx#azure) 
-- [Kubernetes Service Account Tokens](../step-ca/provisioners.mdx#k8ssa-kubernetes-service-account) 
-- [SCEP protocol](../step-ca/provisioners.mdx#scep)
-- [JWT for building custom integrations](../step-ca/provisioners.mdx#jwt)
+- [ACME protocol](./provisioners.mdx#acme)
+- [OAuth/OIDC Single Sign-on](./provisioners.mdx#oauthoidc-single-sign-on)
+- [AWS Instance Identity Documents](./provisioners.mdx#aws)
+- [Google Cloud Instance Identity Tokens](./provisioners.mdx#gcp)
+- [Azure Instance Metadata Service](./provisioners.mdx#azure) 
+- [Kubernetes Service Account Tokens](./provisioners.mdx#k8ssa-kubernetes-service-account) 
+- [SCEP protocol](./provisioners.mdx#scep)
+- [JWT for building custom integrations](./provisioners.mdx#jwt)
 
 ## Active vs. passive revocation
 
@@ -67,7 +67,7 @@ Therefore, certificates should have a shorter lifetime to reduce the value of a 
 With certificate issuance policies administrators can configure what Subjects, SANs and Principals the CA is allowed to sign.
 An example of a policy is to only allow (strict) subdomains of `internal.example.com`, which would be encoded as `*.internal.example.com`.
 
-Visit the [`step-ca` policy](../step-ca/policies.mdx) page to learn how certificate issuance policies work and how they can be configured.
+Visit the [`step-ca` policy](./policies.mdx) page to learn how certificate issuance policies work and how they can be configured.
 
 ## Templates
 
@@ -82,9 +82,9 @@ With certificate templates, you can do things like:
 - Make longer certificate chains, with multiple intermediate CAs
 - Use SSH `force-command` or `source-address` extensions
 - Add conditionals around a certificate's parameters, and fail if they are not met
-- Enrich a certificate with data [from a webhook](../step-ca/webhooks.mdx)
+- Enrich a certificate with data [from a webhook](./webhooks.mdx)
 
-Visit the [`step-ca` templates](../step-ca/templates.mdx) page to learn how to use templates.
+Visit the [`step-ca` templates](./templates.mdx) page to learn how to use templates.
 
 ## Other operational modes
 
@@ -108,7 +108,7 @@ When in RA mode, `step-ca` can peer with three kinds of upstream CA:
 
 ![Example PKI topology with StepCAS RA Mode](/graphics/stepcas-ra-mode.png)
 
-To create an RA-based PKI topology, see our [Registration Authority (RA) Mode](../step-ca/registration-authority-ra-mode.mdx) documentation.
+To create an RA-based PKI topology, see our [Registration Authority (RA) Mode](./registration-authority-ra-mode.mdx) documentation.
 
 ### Offline Mode
 
@@ -131,4 +131,4 @@ $ step ca certificate --offline foo.smallstep.com foo.crt foo.key
 
 ## Next Steps
 
-- Read the [Getting Started guide](../step-ca/getting-started.mdx) to set up a CA and get your first certificate.
+- Read the [Getting Started guide](./getting-started.mdx) to set up a CA and get your first certificate.

--- a/step-ca/certificate-authority-server-production.mdx
+++ b/step-ca/certificate-authority-server-production.mdx
@@ -61,11 +61,11 @@ For durability, keep at least two copies of your root key, in separate locations
 5. Configure `step-ca` to use the signed root and intermediate certificates
 6. Configure `step-ca` to access the cloud HSM or KMS intermediate key for online signing operations
 
-See the [Cryptographic Protection](../step-ca/configuration.mdx#cryptographic-protection) section of our [Configuration Guide](../step-ca/configuration.mdx) to learn more about your options for using HSMs or cloud KMS with `step-ca`.
+See the [Cryptographic Protection](./configuration.mdx#cryptographic-protection) section of our [Configuration Guide](./configuration.mdx) to learn more about your options for using HSMs or cloud KMS with `step-ca`.
 
 ### Use Strong Passwords and Store Them Well
 
-When you [initialize your PKI](../step-ca/getting-started.mdx#initialize-your-certificate-authority),
+When you [initialize your PKI](./getting-started.mdx#initialize-your-certificate-authority),
 the root and intermediate private keys will be encrypted with the same password.
 
 Use a password manager to generate random passwords, 
@@ -133,7 +133,7 @@ See our blog [How to Handle Secrets on the Command Line](https://smallstep.com/b
 
 ### Replace Your Default Provisioner
 
-When you [initialize your PKI](../step-ca/getting-started.mdx#initialize-your-certificate-authority),
+When you [initialize your PKI](./getting-started.mdx#initialize-your-certificate-authority),
 a default `JWK` provisioner will be created.
 If you're not going to use this provisioner,
 we recommend deleting it.
@@ -142,7 +142,7 @@ If you _are_ going to use this provisioner,
 secure it with a different password than your CA's signing keys.
 You can do this by passing separate `--password-file` and `--provisioner-password-file` files when running `step ca init`.
 
-See the section on [managing provisioners](../step-ca/provisioners.mdx#provisioner-management).
+See the section on [managing provisioners](./provisioners.mdx#provisioner-management).
 
 ### Use Short-Lived Certificates
 
@@ -151,10 +151,10 @@ We recommend the following:
 - Host or service account certificates should have a lifetime of one month or less.
 
 Certificates from `step-ca` expire in 24 hours by default.
-We made it easy for you to [automate the renewal of your certificates](../step-ca/renewal.mdx) using the `step` command.
+We made it easy for you to [automate the renewal of your certificates](./renewal.mdx) using the `step` command.
 Carpe diem!
 
-You can [configure certificate lifetimes](../step-ca/configuration.mdx#basic-configuration-options) in the `ca.json` file. 
+You can [configure certificate lifetimes](./configuration.mdx#basic-configuration-options) in the `ca.json` file. 
 
 <Alert severity="info">
   <div>
@@ -280,7 +280,7 @@ Source: [OpenSSL PKI Tutorial](https://pki-tutorial.readthedocs.io/en/latest/cad
 
 Because certificate templates add a lot of flexibility to `step-ca`,
 they can be a source of subtle vulnerabilities in your PKI.
-If you use [custom certificate templates](../step-ca/templates.mdx), be sure they are tightly restricted for your use case.
+If you use [custom certificate templates](./templates.mdx), be sure they are tightly restricted for your use case.
 Use extreme caution when referencing user-supplied data marked as `Insecure` in templates.
 
 ### Create a Service User to Run `step-ca`
@@ -468,14 +468,14 @@ A few things to consider / implement when running multiple instances of `step-ca
   sent `SIGHUP` or restarted. It's recommended to use a configuration management
   tool (ansible, chef, salt, puppet, etc.) to synchronize `ca.json` across instances.
 
-[db-ref]: ../step-ca/configuration.mdx#databases
+[db-ref]: ./configuration.mdx#databases
 
 ## Load balancing or proxying `step-ca` traffic
 
 If you need to place a load balancer or reverse proxy downstream from the CA, we recommend using layer 4 (TCP)
 load balancing or proxying (aka "TLS passthrough").
 
-We also recommend enabling [remote provisioner management](../step-ca/provisioners.mdx#remote-provisioner-management) so that your provisioner configuration can be shared by all `step-ca` instances.
+We also recommend enabling [remote provisioner management](./provisioners.mdx#remote-provisioner-management) so that your provisioner configuration can be shared by all `step-ca` instances.
 
 Layer 7 proxying is _not recommended_, becase the `step` toolchain is built around TLS:
 - `step` expects to be able to perform a TLS handshake with `step-ca`, using the CA's root certificate
@@ -502,13 +502,13 @@ Layer 7 proxying is _not recommended_, becase the `step` toolchain is built arou
 
 We recommend automating certificate renewal when possible.
 Renewal can be easily automated in many environments.
-See our [Renewal](../step-ca/renewal.mdx) documentation for details.
+See our [Renewal](./renewal.mdx) documentation for details.
 
 ## X.509 Certificate Revocation
 
 By default, `step-ca` uses passive revocation.
 Certificates can be revoked using the `step ca revoke` subcommand.
-See our [Revocation](../step-ca/revocation.mdx) documentation for details.
+See our [Revocation](./revocation.mdx) documentation for details.
 
 ## Sane Cryptographic Defaults
 

--- a/step-ca/configuration.mdx
+++ b/step-ca/configuration.mdx
@@ -263,7 +263,7 @@ CA's keys.
 - **authority**: controls the request authorization and signature processes.
 
   - **type**: the type of backing CA service that issues certificates for this step-ca instance. The default is an internal certificate authority service.
-  Other options can [turn `step-ca` into a Registration Authority](../step-ca/registration-authority-ra-mode.mdx): `stepcas` uses a remote `step-ca` instance as the backend, `cloudcas` uses Google CloudCAS, `vaultcas` uses Hashicorp Vault.
+  Other options can [turn `step-ca` into a Registration Authority](./registration-authority-ra-mode.mdx): `stepcas` uses a remote `step-ca` instance as the backend, `cloudcas` uses Google CloudCAS, `vaultcas` uses Hashicorp Vault.
 
   - **template**: default ASN1DN values for new certificates.
 
@@ -296,11 +296,11 @@ CA's keys.
   - **disableIssuedAtCheck**: ☠️  disable a check verifying that provisioning tokens must be issued after the CA has booted. This claim is one prevention
  against token reuse. The default value is false. Do not change this unless you know what you are doing.
 
-  - **provisioners**: list of provisioners. Each provisioner has a name, associated authentication attributes, and an optional claims attribute that will override any values set in the global claims directly underneath authority. The [`step ca provisioner`](../step-cli/reference/ca/provisioner) command group can be used to add, modify, and remove provisioners. See the [provisioner documentation](../step-ca/provisioners.mdx) for details.
+  - **provisioners**: list of provisioners. Each provisioner has a name, associated authentication attributes, and an optional claims attribute that will override any values set in the global claims directly underneath authority. The [`step ca provisioner`](../step-cli/reference/ca/provisioner) command group can be used to add, modify, and remove provisioners. See the [provisioner documentation](./provisioners.mdx) for details.
 
     - **claims**: Each provisioner can define an optional `claims` attribute. The settings in this attribute override any settings in the global `claims` attribute in the authority configuration. See the authority's **claims** section above for a complete list of options.
 
-    - **options**: Each provisioner can define an optional `options` attribute. This attribute allows an operator to set templates that will be applied to all X.509 or SSH certificates generated using the provisioner. See the [templates documentation](../step-ca/templates.mdx) for details.
+    - **options**: Each provisioner can define an optional `options` attribute. This attribute allows an operator to set templates that will be applied to all X.509 or SSH certificates generated using the provisioner. See the [templates documentation](./templates.mdx) for details.
 
   - **password**: ☠️  plain text password for starting the CA. Used to decrypt the intermediate private key. 
 
@@ -316,7 +316,7 @@ CA's keys.
 ## Provisioners
 
 Provisioners are people or entities that are registered with the certificate authority and 
-authorized to issue certificates. Visit the [`step-ca` provisioners](../step-ca/provisioners.mdx) page to learn about the 
+authorized to issue certificates. Visit the [`step-ca` provisioners](./provisioners.mdx) page to learn about the 
 different provisioners, their target use cases, and how to add, remove, and configure them.
 
 ## Policy
@@ -332,7 +332,7 @@ Some examples of policies you can configure are:
 - An `email` rule for `@devops`, matching all SSH user principals in the `@devops` domain.
 - A `uri` rule for `*.example.com`, matching all URIs for subdomains of `example.com`, ignoring the URI scheme, path, query and fragment parts.
 
-Visit the [`step-ca` policy](../step-ca/policies.mdx) page to learn how certificate issuance policies work and how they can be configured.
+Visit the [`step-ca` policy](./policies.mdx) page to learn how certificate issuance policies work and how they can be configured.
 
 <Alert severity="info">
   <AlertTitle>Need more control?</AlertTitle>
@@ -354,7 +354,7 @@ These include things like:
 - Embed SSH `force-command` or `source-address` extensions
 - Evaluate basic logic operations on certificate's parameters, and fail if requirements are not met
 
-Visit the [`step-ca` templates](../step-ca/templates.mdx) page to learn how to use templates.
+Visit the [`step-ca` templates](./templates.mdx) page to learn how to use templates.
 
 ## Databases
 

--- a/step-ca/getting-started.mdx
+++ b/step-ca/getting-started.mdx
@@ -30,8 +30,8 @@ Here are some of the most popular options:
 * Pass `--ssh` if you want to use SSH certificates (in addition to X.509)
 * Pass separate `--password-file` and `--provisioner-password-file` flags to set different signing CA and provisioner passwords.
 * Pass `--helm` to generate Helm YAML for use with [our Helm chart](https://github.com/smallstep/helm-charts/tree/master/step-certificates)
-* Pass `--acme` to create an [ACME provisioner](../step-ca/provisioners.mdx#acme)
-* Pass `--remote-management` to enable [Remote Provisioner Management](../step-ca/provisioners.mdx#remote-provisioner-management)
+* Pass `--acme` to create an [ACME provisioner](./provisioners.mdx#acme)
+* Pass `--remote-management` to enable [Remote Provisioner Management](./provisioners.mdx#remote-provisioner-management)
 
 <Alert severity="success">
   <AlertTitle>Don&apos;t want to run your own CA?</AlertTitle>
@@ -87,7 +87,7 @@ Please enter the password to decrypt /Users/bob/.step/secrets/intermediate_ca_ke
 
 #### Accessing your CA
 
-You can use [`step ca`](../step-cli/reference/ca) and [`step ssh`](../step-cli/reference/ssh) command groups to interact with the CA. See [Basic CA Operations](../step-ca/basic-certificate-authority-operations.mdx) for an overview of common operations.
+You can use [`step ca`](../step-cli/reference/ca) and [`step ssh`](../step-cli/reference/ssh) command groups to interact with the CA. See [Basic CA Operations](./basic-certificate-authority-operations.mdx) for an overview of common operations.
 
 #### Accessing your CA remotely
 
@@ -107,7 +107,7 @@ The root certificate has been saved in /home/alice/.step/certs/root_ca.crt.
 Your configuration has been saved in /home/alice/.step/config/defaults.json.
 ```
 
-This command will download the root CA certificate and write CA connection details to `$HOME/.step/config/defaults.json`. The `step` command will now trust your CA. See [Basic CA Operations](../step-ca/basic-certificate-authority-operations.mdx) for an overview of common operations.
+This command will download the root CA certificate and write CA connection details to `$HOME/.step/config/defaults.json`. The `step` command will now trust your CA. See [Basic CA Operations](./basic-certificate-authority-operations.mdx) for an overview of common operations.
 
 <Alert severity="info">
     <AlertTitle>
@@ -228,8 +228,8 @@ Nice! You've just generated and integrated our first certificate using `step-ca`
 
 ## Next Steps
 
-* Familiarize yourself with [Basic CA Operations](../step-ca/basic-certificate-authority-operations.mdx) using `step ca` and `step ssh` command groups.
-* Check out the [Configuration](../step-ca/configuration.mdx) and [Core Concepts](../step-ca/certificate-authority-core-concepts.mdx) sections to learn more about tailoring
+* Familiarize yourself with [Basic CA Operations](./basic-certificate-authority-operations.mdx) using `step ca` and `step ssh` command groups.
+* Check out the [Configuration](./configuration.mdx) and [Core Concepts](./certificate-authority-core-concepts.mdx) sections to learn more about tailoring
 `step-ca` to your infrastructure needs.
 * Or, head straight to our [tutorials](../tutorials) to see more examples of using `step-ca` in the wild.
 

--- a/step-ca/integrations.mdx
+++ b/step-ca/integrations.mdx
@@ -41,7 +41,7 @@ is a fully functional private ACME server that works with all popular ACME clien
 Learn more about how to [setup your own private ACME server][private-acme-server] and [configure 
 popular ACME clients to use that server][configure-acme].
 
-[private-acme-server]: ../step-ca/acme-basics.mdx
+[private-acme-server]: ./acme-basics.mdx
 [configure-acme]: ../tutorials/acme-protocol-acme-clients.mdx
 
 ### SCEP
@@ -49,7 +49,7 @@ popular ACME clients to use that server][configure-acme].
 The `step-ca` server includes support for certificate enrollment using the [SCEP protocol][scep-rfc]. See our [SCEP provisioner documentation][scep-docs] for details.
 
 [scep-rfc]: https://datatracker.ietf.org/doc/rfc8894/
-[scep-docs]: ../step-ca/provisioners.mdx#scep
+[scep-docs]: ./provisioners.mdx#scep
 
 ### OIDC
 
@@ -58,7 +58,7 @@ credentials in exchange for OIDC tokens.
 
 Learn more about how to [configure an OIDC provisioner][configure-oidc].
 
-[configure-oidc]: ../step-ca/provisioners.mdx#oauthoidc-single-sign-on
+[configure-oidc]: ./provisioners.mdx#oauthoidc-single-sign-on
 
 ### Cloud Instance Identity
 
@@ -71,7 +71,7 @@ credentials in exchange for IIDs from AWS, GCP, and Azure.
 
 Learn more about how to [configure a cloud identity document provisioner][configure-iid].
 
-[configure-iid]: ../step-ca/provisioners.mdx#cloud-provisioners
+[configure-iid]: ./provisioners.mdx#cloud-provisioners
 
 ### Kubernetes
 
@@ -87,7 +87,7 @@ We have two integration options with `cert-manager`:
 
 The [Nebula](https://github.com/slackhq/nebula) networking service supports encrypted overlay networks. Nebula uses certificates to authenticate clients joining the network. Nebula has its own custom certificate format (it's not X.509).
 
-`step-ca` has a [Nebula provisioner](../step-ca/provisioners.mdx) that can exchange Nebula host certificates issued by your Nebula CA for TLS or SSH certificates that have the same SANs or principals. Use this provisioner to simplify host enrollment on a Nebula network.
+`step-ca` has a [Nebula provisioner](./provisioners.mdx) that can exchange Nebula host certificates issued by your Nebula CA for TLS or SSH certificates that have the same SANs or principals. Use this provisioner to simplify host enrollment on a Nebula network.
 
 ### Envoy Secret Discovery Service (SDS)
 
@@ -107,16 +107,16 @@ Learn more about how to [install and configure `step-sds`][step-sds].
 Cloud Key Management Services allow users to store cryptographic keys and sign certificates
 using cloud storage and APIs.
 Integrations with Google Cloud KMS, Amazon AWS KMS, and Azure Key Vault are currently supported.
-[Learn more.](../step-ca/configuration.mdx#cryptographic-protection)
+[Learn more.](./configuration.mdx#cryptographic-protection)
 
 ### YubiKey PIV
 
 Want to store your CA locally on a YubiKey? `step-ca` supports the YubiKey PIV application.
-[Learn more.](../step-ca/configuration.mdx#yubikey-piv)
+[Learn more.](./configuration.mdx#yubikey-piv)
 
 ### PKCS#11 HSMs
 
 `step-ca` supports PKCS#11 hardware security modules (HSMs).
-[Learn more.](../step-ca/configuration.mdx#pkcs-11)
+[Learn more.](./configuration.mdx#pkcs-11)
 
 

--- a/step-ca/provisioners.mdx
+++ b/step-ca/provisioners.mdx
@@ -89,7 +89,7 @@ Fields in <Code>ca.json</Code> may be encoded differently than you expect.</p>
 </Alert>
 
 Some provisioner options override global defaults for your CA.
-For a list of global options, see the [configuration guide](../step-ca/configuration.mdx) section for the `authority` configuration block.
+For a list of global options, see the [configuration guide](./configuration.mdx) section for the `authority` configuration block.
 
 A remote provisioner management API can be enabled in `step-ca`.
 It is disabled by default.
@@ -97,7 +97,7 @@ With remote provisioner management, the CA's provisioner configuration is stored
 
 This feature can be useful if you
 have multiple CA administrators,
-[run several load-balanced](../step-ca/certificate-authority-server-production.mdx#load-balancing-or-proxying-step-ca-traffic) `step-ca` instances,
+[run several load-balanced](./certificate-authority-server-production.mdx#load-balancing-or-proxying-step-ca-traffic) `step-ca` instances,
 or if you want to manage your provisioners remotely (eg. with Infrastructure as Code (IaC) tools; [see below](#unattended-remote-provisioner-management)).
 
 See [Remote Provisioner Management](#remote-provisioner-management) for more.
@@ -854,7 +854,7 @@ The [ACME Protocol](https://tools.ietf.org/html/rfc8555) can authenticate Certif
 
 ACME clients must answer challenges presented by the ACME server to prove to the CA that they control the identifiers listed in the CSR.
 ACME supports four different types of challenges: `http-01`, `dns-01`, `tls-alpn-01`, and `device-attest-01`. These are designed for operability in different environments.
-See [ACME Basics](../step-ca/acme-basics.mdx#acme-challenges) for a description of each challenge type and their tradeoffs.
+See [ACME Basics](./acme-basics.mdx#acme-challenges) for a description of each challenge type and their tradeoffs.
 
 In a typical setup, an ACME server might issue server certificates via the `http-01`, `dns-01`, `tls-alpn-01` challenge types, and client certificates via the `device-attest-01` challenge type.
 
@@ -904,7 +904,7 @@ see the [claims](configuration.mdx#claims) section for all the options.
 
 <br /><br />
 
-See [ACME Basics](../step-ca/acme-basics.mdx)
+See [ACME Basics](./acme-basics.mdx)
 for more guidance on configuring and using the ACME protocol with `step-ca`.
 
 #### ACME for Device Attestation

--- a/step-ca/registration-authority-ra-mode.mdx
+++ b/step-ca/registration-authority-ra-mode.mdx
@@ -43,7 +43,7 @@ When in RA mode, `step-ca` can peer with one of three types of upstream CA:
 
 StepCAS allows configuring a `step-ca` server as an RA, with a second, upstream `step-ca` server acting as the main CA.
 
-StepCAS supports the [JWK](../step-ca/provisioners.mdx#jwk) and [X5C](../step-ca/provisioners.mdx#x5c-x509-certificate) provisioners for requests between RAs and the CA.
+StepCAS supports the [JWK](./provisioners.mdx#jwk) and [X5C](./provisioners.mdx#x5c-x509-certificate) provisioners for requests between RAs and the CA.
 The JWK provisioner balances security and simplicity, and it covers the most common use cases.
 The X5C provisioner allows for more complex trust relationships and expiring certificates,
 but it requires setting up ongoing certificate lifecycle management on the RAs.
@@ -61,7 +61,7 @@ Configure additional RA provisioners just as you would configure provisioners fo
 
 ### Setting up the CA
 
-You can set up the CA using the [Getting Started](../step-ca/getting-started.mdx) guide.
+You can set up the CA using the [Getting Started](./getting-started.mdx) guide.
 You will need the name and password of the first provisioner you created when running [`step ca init`](../step-cli/reference/ca/init).
 
 ### Setting up the RA
@@ -512,7 +512,7 @@ We'll need the `VAULT_ROLE_ID` and `VAULT_SECRET_ID` to configure our RA in the 
 In this section, we'll initialize a basic CA,
 and then convert it into an RA.
 
-First, run `step ca init` as described in [Getting Started](../step-ca/getting-started.mdx).
+First, run `step ca init` as described in [Getting Started](./getting-started.mdx).
 Configure the DNS names, address, and JWK provisioner password.
 
 Once the PKI is initialized, let's update `ca.json` to enable RA functionality.

--- a/step-ca/renewal.mdx
+++ b/step-ca/renewal.mdx
@@ -6,7 +6,7 @@ description: Learn how to renew certificates and set up automated renewals
 
 By default, `step-ca` issues short-lived certificates that expire after 24
 hours. Short-lived certificates are excellent security hygiene because they
-offer regular key rotation and [passive revocation](../step-ca/revocation.mdx)
+offer regular key rotation and [passive revocation](./revocation.mdx)
 
 Short-lived certificates create a problem though: For any long-lived workloads,
 you will need to renew your certificates each day before they expire. This
@@ -62,7 +62,7 @@ X.509v3 TLS Certificate (ECDSA P-256) [Serial: 2599...1204]
 
 By default, `step-ca` issues certificates valid for 24 hours. This is suitably
 short for many scenarios. If it's not right for you, you can adjust the
-[`defaultTLSCertDuration`](../step-ca/provisioners.mdx#claims) per provisioner
+[`defaultTLSCertDuration`](./provisioners.mdx#claims) per provisioner
 or pass the `--not-after` flag to the [`step ca certificate`](../step-cli/reference/ca/certificate) to adjust the
 lifetime of an individual certificate. Very short lifetimes (eg. five minutes)
 are better from a security perspective, but this can be difficult in
@@ -406,7 +406,7 @@ Be sure the user (in this example, `step`) has write access to the certificate a
 [`step ca renew`](../step-cli/reference/ca/renew) allows a certificate owner to extend the lifetime of a certificate before it expires.
 Unfortunately, it also lets an attacker with the private key do the same thing.
 To prevent this, you need to explicitly tell `step-ca` to revoke a retired certificate.
-See the [certificate revocation section](../step-ca/revocation.mdx) for details.
+See the [certificate revocation section](./revocation.mdx) for details.
 
 #### Renewal after expiry: For intermittently-connected devices
 
@@ -416,7 +416,7 @@ but it's useful if you have devices with intermittent network connectivity.
 The device will be able to renew its certificate the next time it has network access,
 provided the certificate has not been revoked.
 
-To configure renewal after expiry for a provisioner, pass the `--allow-renewal-after-expiry` flag to the [`step ca provisioner`](../step-cli/reference/ca/provisioner) management commands. See [managing provisioners](../step-ca/provisioners.mdx#managing-provisioners).
+To configure renewal after expiry for a provisioner, pass the `--allow-renewal-after-expiry` flag to the [`step ca provisioner`](../step-cli/reference/ca/provisioner) management commands. See [managing provisioners](./provisioners.mdx#managing-provisioners).
 
 <Alert severity="warning">
   <div>

--- a/step-ca/webhooks.mdx
+++ b/step-ca/webhooks.mdx
@@ -14,9 +14,9 @@ description: Webhooks augment the data available to certificate templates
 
 Webhooks let you enrich X.509 or SSH certificates with data requested from an external endpoint.
 The CA fetches key/value pairs from a configured webhook when a CSR is being processed,
-and the webhook data is passed along to the provisioner's [certificate template](../step-ca/templates.mdx).
+and the webhook data is passed along to the provisioner's [certificate template](./templates.mdx).
 
-Attach webhooks to [provisioners](../step-ca/provisioners.mdx) via the `step ca provisioner webhook` command group.
+Attach webhooks to [provisioners](./provisioners.mdx) via the `step ca provisioner webhook` command group.
 
 ## Quickstart
 

--- a/step-cli/basic-crypto-operations.mdx
+++ b/step-cli/basic-crypto-operations.mdx
@@ -21,11 +21,11 @@ Here's a few common uses of the `step` command:
 
 ## Requirements
 
-- [`step`](../step-cli)
+- [`step`](./README.mdx)
 
 ## Create and work with X.509 certificates
 
-Let's take a look at the [`step certificate`](../step-cli/reference/certificate/) command group.
+Let's take a look at the [`step certificate`](./reference/certificate/) command group.
 This command group is a Swiss Army knife for working with certificates.
 You can use it to create certificate signing requests (CSRs),
 sign CSRs,
@@ -97,7 +97,7 @@ To inspect the certificate you just made, run:
           to:  2021-09-02T20:48:40Z`}
 </CodeBlock>
 
-You can get a certificate in JSON format by calling [`step certificate inspect`](../step-cli/reference/certificate/inspect) with `--format json`. This example [uses jq](https://stedolan.github.io/jq/) to parse the JSON and extract a specific value:
+You can get a certificate in JSON format by calling [`step certificate inspect`](./reference/certificate/inspect) with `--format json`. This example [uses jq](https://stedolan.github.io/jq/) to parse the JSON and extract a specific value:
 
 ```shell-session nocopy
 $ step certificate inspect example.com.crt --format json | jq -r .validity.end
@@ -133,11 +133,11 @@ For a dry run, you can use Let's Encrypt's staging server URL: `https://acme-sta
 ## Generate JSON Web Tokens (JWTs) and JSON Web Keys (JWKs)
 
 The following command groups work with JOSE objects like JWTs and JWEs:
-* [`step crypto jwt`](../step-cli/reference/crypto/jwt)
-* [`step crypto jwk`](../step-cli/reference/crypto/jwk)
-* [`step crypto jwe`](../step-cli/reference/crypto/jwe)
-* [`step crypto jws`](../step-cli/reference/crypto/jws)
-* [`step crypto jose`](../step-cli/reference/crypto/jose)
+* [`step crypto jwt`](./reference/crypto/jwt)
+* [`step crypto jwk`](./reference/crypto/jwk)
+* [`step crypto jwe`](./reference/crypto/jwe)
+* [`step crypto jws`](./reference/crypto/jws)
+* [`step crypto jose`](./reference/crypto/jose)
 
 In this example, you'll create a [JSON Web Key](https://tools.ietf.org/html/rfc7517) (JWK), add the public key to a keyset, and sign a [JSON Web Token](https://tools.ietf.org/html/rfc7519) (JWT) that expires in 15 minutes:
 
@@ -177,7 +177,7 @@ We can then verify the JWT and return the payload:
 
 ## Obtain and Work With OAuth Tokens
 
-The [`step oauth`](../step-cli/reference/oauth/) command group supports API authorization and single sign on with OAuth and OIDC.
+The [`step oauth`](./reference/oauth/) command group supports API authorization and single sign on with OAuth and OIDC.
 
 This command group requires that you supply your own OAuth provider URL, client ID, and client secret.
 
@@ -208,7 +208,7 @@ $ echo $TOKEN | step crypto jwt verify \
 
 ### Generate TOTP Tokens for Multi-Factor Authentication (MFA)
 
-With [`step crypto otp`](../step-cli/reference/crypto/otp), you can generate a [TOTP](https://en.wikipedia.org/wiki/Time-based_One-time_Password_algorithm) token and a QR code:
+With [`step crypto otp`](./reference/crypto/otp), you can generate a [TOTP](https://en.wikipedia.org/wiki/Time-based_One-time_Password_algorithm) token and a QR code:
 
 ```shell
 step crypto otp generate \
@@ -224,11 +224,11 @@ step crypto otp verify --secret smallstep.totp
 
 ### Sign and Encrypt Arbitrary Data
 
-You can use the [`step crypto nacl`](../step-cli/reference/crypto/nacl) command group to sign or encrypt arbitrary data for internal use. This command group uses the [NaCl library](https://nacl.cr.yp.to/)'s high-speed crypto primitives.
+You can use the [`step crypto nacl`](./reference/crypto/nacl) command group to sign or encrypt arbitrary data for internal use. This command group uses the [NaCl library](https://nacl.cr.yp.to/)'s high-speed crypto primitives.
 
 ### Work with SSH Certificates
 
-The [`step ssh`](../step-cli/reference/ssh/) command group is usually used in conjunction with `step-ca`'s SSH CA functionality. But not all the subcommands require an SSH CA. You can inspect an SSH certificate:
+The [`step ssh`](./reference/ssh/) command group is usually used in conjunction with `step-ca`'s SSH CA functionality. But not all the subcommands require an SSH CA. You can inspect an SSH certificate:
 
 ```shell-session nocopy
 $ step ssh inspect < mycert.crt

--- a/step-cli/the-step-command.mdx
+++ b/step-cli/the-step-command.mdx
@@ -11,7 +11,7 @@ description: The `step` Command
 `step` ships with extensive built-in help. To list available options and command groups, run `step` by itself. For help, use `step help <command>` or `step help <command> <subcommand>`.
 
 ## Environment variables
-- `STEPPATH` The path where `step` stores configuration and state. This directory also holds `step-ca` state created with [`step ca init`](../step-cli/reference/ca/init), including CA configuration, keys, certificates, and templates. Defaults to `$HOME/.step`.
+- `STEPPATH` The path where `step` stores configuration and state. This directory also holds `step-ca` state created with [`step ca init`](./reference/ca/init), including CA configuration, keys, certificates, and templates. Defaults to `$HOME/.step`.
 - `STEPDEBUG` When set to `1`, `step` will provide extra diagnostic information for debugging. This variable can also be used with `step-ca`.
 - `HTTPS_PROXY` and `NO_PROXY` Configure proxies for outbound HTTPS traffic. See [net/http.ProxyFromEnvironment](https://golang.org/pkg/net/http/#ProxyFromEnvironment) documentation for details. Note that the system trust store is _not_ trusted by `step` for the TLS handshake with the proxy server.
   - The proxy server will need to be configured to trust the CA.
@@ -69,17 +69,17 @@ $ step path
 ```
 
 Contexts are enabled, and a new context is created, if `--context [name]` is passed to any of the following:
-- CA client bootstrap: [`step ca bootstrap`](../step-cli/reference/ca/bootstrap)
-- CA server init: [`step ca init`](../step-cli/reference/ca/init)
+- CA client bootstrap: [`step ca bootstrap`](./reference/ca/bootstrap)
+- CA server init: [`step ca init`](./reference/ca/init)
 - CA server startup: `step-ca`
-- SSH client bootstrap: [`step ssh config`](../step-cli/reference/ssh/config)
+- SSH client bootstrap: [`step ssh config`](./reference/ssh/config)
 
 When contexts are enabled:
 - Client configuration is stored in the `profiles` directory, and CA server configuration and data is stored in `authorities` directory.
 - Context configuration files `contexts.json` and `current-context.json` are created in the top-level `$STEPPATH`.
-- There is always a currently active context ([`step context current`](../step-cli/reference/context/current)), but you can pass a `--context` name to any [`step ca`](../step-cli/reference/ca), [`step ssh`](../step-cli/reference/ssh/), or `step-ca` command to temporarily select a context for a single operation.
-- Use the [`step context`](../step-cli/reference/context/) command group to switch contexts, remove a context and its associated configuration, and view the current context.
-- The [`step path`](../step-cli/reference/path/) command will show the current context's path. To display the top-level configuration directory name (`$STEPPATH`) when contexts are enabled, use `step path --base`.
+- There is always a currently active context ([`step context current`](./reference/context/current)), but you can pass a `--context` name to any [`step ca`](./reference/ca), [`step ssh`](./reference/ssh/), or `step-ca` command to temporarily select a context for a single operation.
+- Use the [`step context`](./reference/context/) command group to switch contexts, remove a context and its associated configuration, and view the current context.
+- The [`step path`](./reference/path/) command will show the current context's path. To display the top-level configuration directory name (`$STEPPATH`) when contexts are enabled, use `step path --base`.
 - Two [`defaults.json`](#configuration-file) files are created: One in the `profiles` tree, and one in the `authorities` tree. They are merged, and the one in `profiles` takes precedence.
 - Context configuration files `contexts.json` and `current-context.json` are created in the top-level `$STEPPATH`.
 
@@ -98,4 +98,4 @@ If you're writing a plugin, please follow our convention for CLI help by impleme
 
 ## Next Steps
 
-* [Basic Crypto Operations](../step-cli/basic-crypto-operations.mdx)
+* [Basic Crypto Operations](./basic-crypto-operations.mdx)


### PR DESCRIPTION
This should fix 404s in the docs that have emerged because the remark links plugin is not handling `../current-dir` properly on staging and prod. 

Also, this PR makes the link checker run green for the first time ever!!