### PR TITLE
Update acme-protocol-acme-clients.mdx

### DIFF
--- a/tutorials/acme-protocol-acme-clients.mdx
+++ b/tutorials/acme-protocol-acme-clients.mdx
@@ -242,6 +242,20 @@ tls carl@smallstep.com {
 }
 ```
 
+If caddy is already bound to port 80 (as reverse proxies typically are), then you **_must_** use TLS-ALPN-01 challenges instead of the default HTTP-01 because HTTP-01 challenges must be performed on port 80 per the [ACME standard](https://letsencrypt.org/docs/challenge-types/) ([RFC-8555](https://datatracker.ietf.org/doc/html/rfc8555#section-8.3)). Here is an example of this (ref: [caddy docs](https://caddyserver.com/docs/caddyfile/directives/tls#acme)):
+
+```
+foo.internal {
+        tls {
+                issuer acme https://ca.internal/acme/acme/directory {
+                        email carl@smallstep.com
+                        disable_http_challenge
+                        trusted_roots <step path>/certs/root_ca.crt
+                }
+        }
+}
+```
+
 Replace `<step path>` with the output of the [`step path`](../step-cli/reference/path/) command.
 
 Now run `caddy` to start serving HTTPS!


### PR DESCRIPTION
Added section on configuring Caddy to use TLS-ALPN-01 challenges instead of HTTP-01 when caddy is bound to port 80.

#### Name of feature: Caddy TLS-ALPN-01 challenge example

#### Pain or issue this feature alleviates: Using caddy as ACME client when bound to port 80.

#### Why is this important to the project (if not answered above): Helps users configure caddy for ACME challenges.

#### Supporting links/other PRs/issues: https://discord.com/channels/837031272227930163/841243933936975912/1101584170855190638

💔Thank you!
