### PR TITLE
Link fixes on SSH index page

### DIFF
--- a/ssh/README.mdx
+++ b/ssh/README.mdx
@@ -28,17 +28,13 @@ you haven't already.
 
 Start by configuring SSH access on your laptop:
 
-<ContentLink icon={<FileWithFlippedCornerIcon />} href="client">
-  Client Quickstart Guide &gt;
-</ContentLink>
+**[Client Quickstart Guide](./client.mdx)**
 
 ## Step 2: Register Hosts
 
 Register your hosts with Smallstep SSH:
 
-<ContentLink icon={<FileWithFlippedCornerIcon />} href="hosts">
-  Host Quickstart Guide &gt;
-</ContentLink>
+**[Host Quickstart Guide](./client.mdx)**
 
 ## Step 3: Set up Single Sign-on and Directory Sync
 
@@ -47,17 +43,11 @@ identity provider. Note: Single Sign-on through your identity provider requires
 SSH Professional + Team level account or higher. [Click here for more pricing
 information] (/sso-ssh/pricing/#pricing).
 
-<ContentLink icon={<FileWithFlippedCornerIcon />} href="/docs/ssh/azure-ad">
-  Azure AD Quickstart Guide &gt;
-</ContentLink>
+**[Azure AD Quickstart Guide](./azure-ad.mdx")**
 
-<ContentLink icon={<FileWithFlippedCornerIcon />} href="/docs/ssh/g-suite">
-  G Suite Quickstart Guide &gt;
-</ContentLink>
+**[G Suite Quickstart Guide](./g-suide.mdx)**
 
-<ContentLink icon={<FileWithFlippedCornerIcon />} href="/docs/ssh/okta">
-  Okta Quickstart Guide &gt;
-</ContentLink>
+**[Okta Quickstart Guide](./okta.mdx)**
 
 <Alert severity="info" mt={2}>
   <AlertTitle>Don't see your identity provider?</AlertTitle>
@@ -72,9 +62,7 @@ information] (/sso-ssh/pricing/#pricing).
 
 Establish access control rules:
 
-<ContentLink icon={<FileWithFlippedCornerIcon />} href="/docs/ssh/acls">
-  Access Control Guide &gt;
-</ContentLink>
+**[Access Control Guide](./acls.mdx)**
 
 ## Looking For Technical Details On The Product?
 

--- a/ssh/README.mdx
+++ b/ssh/README.mdx
@@ -34,7 +34,7 @@ Start by configuring SSH access on your laptop:
 
 Register your hosts with Smallstep SSH:
 
-**[Host Quickstart Guide](./client.mdx)**
+**[Host Quickstart Guide](./hosts.mdx)**
 
 ## Step 3: Set up Single Sign-on and Directory Sync
 

--- a/ssh/README.mdx
+++ b/ssh/README.mdx
@@ -43,9 +43,9 @@ identity provider. Note: Single Sign-on through your identity provider requires
 SSH Professional + Team level account or higher. [Click here for more pricing
 information] (/sso-ssh/pricing/#pricing).
 
-**[Azure AD Quickstart Guide](./azure-ad.mdx")**
+**[Azure AD Quickstart Guide](./azure-ad.mdx)**
 
-**[G Suite Quickstart Guide](./g-suide.mdx)**
+**[G Suite Quickstart Guide](./g-suite.mdx)**
 
 **[Okta Quickstart Guide](./okta.mdx)**
 


### PR DESCRIPTION
The `<ContentLink>` component has a different behavior for resolving links, that doesn't match the way we do it everywhere else, but still passes the link checker, so I have removed it in favor of a regular Markdown link.
