### PR TITLE
Make term "trust store" consistent, and suggestions [..]

### DIFF
--- a/certificate-manager/getting-started.mdx
+++ b/certificate-manager/getting-started.mdx
@@ -87,7 +87,7 @@ Run the following command, substituting the values from your Authority's propert
 
 This command will download the CA Root certificate and configure your local `step` client to interact with the Authority.
 
-If desired, you can also use the `step` CLI to [install](../step-cli/reference/certificate/install) the CA Root certificate to your system's truststore.
+If desired, you can also use the `step` CLI to [install](../step-cli/reference/certificate/install) the CA Root certificate to the supported trust stores on your system.
 
 ## Next Steps
 

--- a/certificate-manager/how-it-works.mdx
+++ b/certificate-manager/how-it-works.mdx
@@ -243,7 +243,7 @@ dashboard.
 - [`step ca root`](https://smallstep.com/docs/step-cli/reference/ca/root)
   securely downloads your root certificate.
 
-Once you've downloaded your root certificate, you can add it to your system
+Once you've downloaded your root certificate, you can add it to your system's default
 trust store using
 [`step certificate install`](https://smallstep.com/docs/step-cli/reference/certificate/install):
 

--- a/step-ca/configuration.mdx
+++ b/step-ca/configuration.mdx
@@ -488,7 +488,7 @@ An example database configuration that enables TLS server hostname verification 
 },
 ```
 
-The database driver looks in `$HOME/.postgresql/root.crt` for a PEM bundle of root CAs to trust. When that file is not found, it uses the system CA trust store.
+The database driver looks in `$HOME/.postgresql/root.crt` for a PEM bundle of root CAs to trust. When that file is not found, it uses the system's default trust store.
 Similarly, `$HOME/.postgresql/postgresql.crt` and the corresponding `$HOME/.postgresql/postgresql.key` is used for mutual TLS authentication if these files exist, and if the PostgreSQL server requests a client certificate.
 You can override the locations for these files by providing them in the DSN:
 

--- a/step-ca/getting-started.mdx
+++ b/step-ca/getting-started.mdx
@@ -121,7 +121,7 @@ This command downloads the root CA certificate and writes CA connection details 
 	</div>
 </Alert>
 
-You may also wish to establish system-wide trust of your CA, so your certificates will be trusted by `curl` and other programs. Use the [`step certificate install`](../step-cli/reference/certificate/install) command to install your root CA certificate into your system's trust store:
+You may also wish to establish system-wide trust of your CA, so your certificates will be trusted by `curl` and other programs. Use the [`step certificate install`](../step-cli/reference/certificate/install) command to install your root CA certificate into your system's default trust store:
 
 ```shell-session
 $ step certificate install $(step path)/certs/root_ca.crt
@@ -194,7 +194,7 @@ First, try making a curl request to the example server. In a new terminal, run:
 $ curl https://localhost:9443/hi
 ```
 
-If you already ran [`step certificate install`](../step-cli/reference/certificate/install) to install your root CA into your system's trust store, this command works and you'll see "Hello, World!".
+If you already ran [`step certificate install`](../step-cli/reference/certificate/install) to install your root CA into your system's default trust store, this command works and you'll see "Hello, World!".
 
 If not, you'll see this error:
 

--- a/step-cli/README.mdx
+++ b/step-cli/README.mdx
@@ -29,7 +29,7 @@ Here's a few common uses of the `step` command that don't require `step-ca`:
 - [Inspect an SSH certificate](./basic-crypto-operations.mdx#work-with-ssh-certificates)
 - [Sign and encrypt arbitrary data using the NaCl library](./basic-crypto-operations.mdx#sign-and-encrypt-arbitrary-data)
 - [Generate and verify TOTP tokens for multi-factor authentication (MFA)](./basic-crypto-operations.mdx#generate-totp-tokens-for-multi-factor-authentication-mfa)
-- Add and remove CA certificates from your system's trust store
+- Add and remove CA certificates from your system's default trust store
 
 ## Next Steps
 

--- a/step-cli/basic-crypto-operations.mdx
+++ b/step-cli/basic-crypto-operations.mdx
@@ -81,7 +81,7 @@ $ step certificate verify example.com.crt --roots root_ca.crt
 To get TLS working from here, you'll need to do two things:
 <ul>
 <li>Install the leaf certificate bundle <Code>example.com-bundle.crt</Code> into your server configuration</li>
-<li>Get all of your clients to trust the <Code>root_ca.crt</Code> certificate. You can install the certificate into the system trust store by running <Code>step certificate install root_ca.crt</Code></li>
+<li>Get all of your clients to trust the <Code>root_ca.crt</Code> certificate. You can install the certificate into the system's default trust store by running <Code>step certificate install root_ca.crt</Code></li>
 </ul>
 </Aside>
 

--- a/step-cli/reference/ca/bootstrap/README.mdx
+++ b/step-cli/reference/ca/bootstrap/README.mdx
@@ -42,7 +42,7 @@ After the bootstrap, ca commands do not need to specify the flags
 The `fingerprint` of the targeted root certificate.
 
 **--install**
-Install the root certificate into the system truststore.
+Install the root certificate into the specified trust stores.
 
 **--team**=`ID`
 The team `ID` used to bootstrap the environment.

--- a/step-cli/reference/certificate/README.mdx
+++ b/step-cli/reference/certificate/README.mdx
@@ -91,12 +91,12 @@ Extract the public key from a PEM encoded certificate:
 $ step certificate key foo.crt
 ```
 
-Install a root certificate in the system truststore:
+Install a root certificate in the system's default trust store:
 ```shell
 $ step certificate install root-ca.crt
 ```
 
-Uninstall a root certificate from the system truststore:
+Uninstall a root certificate from the system's default trust store:
 ```shell
 $ step certificate uninstall root-ca.crt
 ```
@@ -116,7 +116,7 @@ $ step certificate uninstall root-ca.crt
 | **[sign](sign/)** | sign a certificate signing request (CSR) |
 | **[verify](verify/)** | verify a certificate |
 | **[key](key/)** | print public key embedded in a certificate |
-| **[install](install/)** | install a root certificate in the system truststore |
-| **[uninstall](uninstall/)** | uninstall a root certificate from the system truststore |
+| **[install](install/)** | install a root certificate in the supported trust stores |
+| **[uninstall](uninstall/)** | uninstall a root certificate from the supported trust stores |
 | **[p12](p12/)** | package a certificate and keys into a .p12 file |
 

--- a/step-cli/reference/certificate/install/README.mdx
+++ b/step-cli/reference/certificate/install/README.mdx
@@ -8,7 +8,7 @@ menu:
 ---
 
 ## Name
-**step certificate install** -- install a root certificate in the system truststore
+**step certificate install** -- install a root certificate in the supported trust stores
 
 ## Usage
 
@@ -20,21 +20,20 @@ step certificate install <crt-file>
 
 ## Description
 
-**step certificate install** installs a root certificate in the system
-truststore.
+**step certificate install** installs a root certificate in supported trust stores.
 
-Java and Firefox truststores are also supported via the respective flags.
+Java's and Firefox's trust stores are also supported via the respective flags.
 
 ## Positional arguments
 
 `crt-file`
-Certificate to install in the system truststore
+Root certificate to install in the specified trust stores.
 
 ## Options
 
 
 **--prefix**=`name`
-The prefix used to `name` the CA in the truststore. Defaults to the
+The prefix used to `name` the CA in the trust store. Defaults to the
 certificate common name.
 
 **--java**
@@ -44,34 +43,34 @@ install on the Java key store
 install on the Firefox NSS security database
 
 **--no-system**
-disables the install on the system truststore
+disables the install on the system's default trust store
 
 **--all**
-install on the system, Firefox and Java truststores
+install in Firefox's, Java's, and the system's default trust store
 
 ## Examples
 
-Install a certificate in the system truststore:
+Install a root certificate in the system's default trust store:
 ```shell
 $ step certificate install root-ca.pem
 ```
 
-Install a certificate in all the supported truststores:
+Install a root certificate in all the supported trust stores:
 ```shell
 $ step certificate install --all root-ca.pem
 ```
 
-Install a certificate in Firefox and the system truststore:
+Install a root certificate in Firefox's and the system's default trust store:
 ```shell
 $ step certificate install --firefox root--ca.pem
 ```
 
-Install a certificate in Java and the system truststore:
+Install a root certificate in Java's and the system's default trust store:
 ```shell
 $ step certificate install --java root-ca.pem
 ```
 
-Install a certificate in Firefox, Java, but not in the system truststore:
+Install a root certificate in Firefox's and Java's trust store, but not in the system's default trust store:
 ```shell
 $ step certificate install --firefox --java --no-system root-ca.pem
 ```

--- a/step-cli/reference/certificate/uninstall/README.mdx
+++ b/step-cli/reference/certificate/uninstall/README.mdx
@@ -8,7 +8,7 @@ menu:
 ---
 
 ## Name
-**step certificate uninstall** -- uninstall a root certificate from the system truststore
+**step certificate uninstall** -- uninstall a root certificate from the supported trust stores
 
 ## Usage
 
@@ -20,21 +20,20 @@ step certificate uninstall <crt-file>
 
 ## Description
 
-**step certificate uninstall** uninstalls a root certificate from the system
-truststore.
+**step certificate uninstall** uninstalls a root certificate from the supported trust stores.
 
-Java and Firefox truststores are also supported via the respective flags.
+Java's and Firefox's trust stores are also supported via the respective flags.
 
 ## Positional arguments
 
 `crt-file`
-Certificate to uninstall from the system truststore
+Root certificate to uninstall from the specified trust stores.
 
 ## Options
 
 
 **--prefix**=`name`
-The prefix used to `name` the CA in the truststore. Defaults to the
+The prefix used to `name` the CA in the trust store. Defaults to the
 certificate common name.
 
 **--java**
@@ -44,29 +43,30 @@ uninstall from the Java key store
 uninstall from the Firefox NSS security database
 
 **--no-system**
-disables the uninstall from the system truststore
+disables the uninstall from the system's default trust store
 
 **--all**
-uninstall from the system, Firefox and Java truststores
+uninstall from Firefox's, Java's, and the system's default trust store
+
 
 ## Examples
 
-Uninstall from only the system truststore:
+Uninstall only from the system's default trust store:
 ```shell
 $ step certificate uninstall root-ca.pem
 ```
 
-Uninstall a certificate from all the supported truststores:
+Uninstall a root certificate from all the supported trust stores:
 ```shell
 $ step certificate uninstall --all root-ca.pem
 ```
 
-Uninstall a certificate from Firefox and the system truststore:
+Uninstall a root certificate from Firefox's and the system's default trust store:
 ```shell
 $ step certificate uninstall --firefox root--ca.pem
 ```
 
-Uninstall a certificate from Java and the system truststore:
+Uninstall a root certificate from Java's and the system's default trust store:
 ```shell
 $ step certificate uninstall --java root-ca.pem
 ```

--- a/step-cli/the-step-command.mdx
+++ b/step-cli/the-step-command.mdx
@@ -13,7 +13,7 @@ description: The `step` Command
 ## Environment variables
 - `STEPPATH` The path where `step` stores configuration and state. This directory also holds `step-ca` state created with [`step ca init`](./reference/ca/init), including CA configuration, keys, certificates, and templates. Defaults to `$HOME/.step`.
 - `STEPDEBUG` When set to `1`, `step` will provide extra diagnostic information for debugging. This variable can also be used with `step-ca`.
-- `HTTPS_PROXY` and `NO_PROXY` Configure proxies for outbound HTTPS traffic. See [net/http.ProxyFromEnvironment](https://golang.org/pkg/net/http/#ProxyFromEnvironment) documentation for details. Note that the system trust store is _not_ trusted by `step` for the TLS handshake with the proxy server.
+- `HTTPS_PROXY` and `NO_PROXY` Configure proxies for outbound HTTPS traffic. See [net/http.ProxyFromEnvironment](https://golang.org/pkg/net/http/#ProxyFromEnvironment) documentation for details. Note that the system's default trust store is _not_ trusted by `step` for the TLS handshake with the proxy server.
   - The proxy server will need to be configured to trust the CA.
   - Only `HTTPS_PROXY` is needed; `step`'s outbound connections are all HTTPS.
   - Add a `--root` or `STEP_ROOT` These files contain both the step CA certificate, and the proxy CA certificate will be trusted by step.

--- a/tutorials/acme-protocol-acme-clients.mdx
+++ b/tutorials/acme-protocol-acme-clients.mdx
@@ -82,7 +82,7 @@ Once your root certificate is installed, no additional client configuration is n
 
 <Alert severity="warning">
   <AlertTitle>A Word of Caution</AlertTitle>
-  Adding a root certificate to your system’s trust store is a global operation. Certificates issued by your CA will be trusted everywhere, including in many web browsers.
+  Adding a root certificate to your system’s default trust store is a global operation. Certificates issued by your CA will be trusted everywhere, including in many web browsers.
 </Alert>
 
 
@@ -544,7 +544,7 @@ Hello, mike@smallstep.com!`}
 
 It's easy to get a certificate from `step-ca` in Traefik v2, using the `tls-alpn-01` ACME challenge type.
 
-Most importantly, Traefik will need to trust your root CA certificate. Either use the `LEGO_CA_CERTIFICATES` environment variable to provide the full path to your `root_ca.crt` when running `traefik`, or install your root certificate in your system's trust store by running `step certificate install root_ca.crt`.
+Most importantly, Traefik will need to trust your root CA certificate. Either use the `LEGO_CA_CERTIFICATES` environment variable to provide the full path to your `root_ca.crt` when running `traefik`, or install your root certificate in your system's default trust store by running `step certificate install root_ca.crt`.
 
 In your Traefik static configuration, you'll need to add a `certificatesResolvers` block:
 


### PR DESCRIPTION
#### Name of feature:

Term consistency

#### Pain or issue this feature alleviates:

Makes it possible to find all instances of the term "trust store".

#### Why is this important to the project (if not answered above):

I find consistency and discoverability of concepts important.

#### Supporting links/other PRs/issues:

None that I know of.

---

From commit message:

> The term "system's default  trust store" is used way more  than  "system  truststore"  or  "system  trust store", but  this commit makes it  consistent across the docs.
> 
> Other amendments:
> 
> + use "root certificate"  instead  of  "certificate" where appropriate to avoid ambiguities
> 
> +  use  "supported  trust  stores"  instead  of  the "system's default trust store" where appropriate

Thank you for taking a look!