### PR TITLE
fix docs: federatedRoots is an array

### DIFF
--- a/step-ca/configuration.mdx
+++ b/step-ca/configuration.mdx
@@ -68,7 +68,7 @@ the `--password-file` flag accepts
 ```json
 {
   "root": "examples/pki/secrets/root_ca.crt",
-  "federatedRoots": "examples/pki/secrets/federated_root_ca.crt",
+  "federatedRoots": ["examples/pki/secrets/federated_root_ca.crt"],
   "crt": "examples/pki/secrets/intermediate_ca.crt",
   "key": "examples/pki/secrets/intermediate_ca_key",
   "address": ":9000",


### PR DESCRIPTION
In the configuration examples, federatedRoots needs to be an array value.

<!---
Please provide answers in the spaces below each prompt, where applicable.
Not every PR requires responses for each prompt.
Use your discretion.
-->
#### Name of feature:
fix docs: federatedRoots is an array

#### Pain or issue this feature alleviates:
bug in documentation. federatedRoots needs to be an array instead of a string in configuration examples.

#### Why is this important to the project (if not answered above):

#### Is there documentation on how to use this feature? If so, where?

#### In what environments or workflows is this feature supported?

#### In what environments or workflows is this feature explicitly NOT supported (if any)?

#### Supporting links/other PRs/issues:

💔Thank you!
