### PR TITLE
This renames commerical tutorials to 'How To Guides'.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -42,7 +42,7 @@
           ]
         },
         {
-          "title": "Tutorials",
+          "title": "How To Guides",
           "routes": [
             {
               "title": "Deploy EAP-TLS Wi-Fi with Jamf Pro + Smallstep",

--- a/tutorials/README.mdx
+++ b/tutorials/README.mdx
@@ -19,6 +19,8 @@ In general, these tutorials assume you have initialized and started up a
 [Getting Started](../step-ca/getting-started.mdx). As an alternative, you can use
 our hosted CA, [Smallstep Certificate Manager](https://smallstep.com/certificate-manager).
 
+<TutorialsList title="Tutorials" />
+
 ## Further Examples & Tutorials
 
 Beyond these docs, we have the following resources available:


### PR DESCRIPTION
It also adds a table of contents for the open source [Tutorials index page](https://smallstep.com/docs/tutorials/).
No URL changes or redirects here — I've only changed the nav title.
