### PR TITLE
Add tls_trust_pool to Proxying step-ca traffic.

### DIFF
--- a/step-ca/certificate-authority-server-production.mdx
+++ b/step-ca/certificate-authority-server-production.mdx
@@ -522,7 +522,9 @@ https://ca.example.com {
     transport http {
       # This allows the proxy to complete a trust
       # chain by trusting step-ca's root.
-      tls_trusted_ca_certs /etc/caddy/root_ca.crt
+      tls_trust_pool file {
+        pem_file /etc/caddy/root_ca.crt
+      }
     }
   }
 }


### PR DESCRIPTION
Update certificate-authority-server-production.mdx

<!---
Please provide answers in the spaces below each prompt, where applicable.
Not every PR requires responses for each prompt.
Use your discretion.
-->
#### Name of feature:
Change of tls trust definition for proxying step-ca traffic. Use of `tls_trust_pool` instead of `tls_trusted_ca_certs`.
#### Pain or issue this feature alleviates:
Inaccessibility of step-ca while proxying with caddy.
#### Why is this important to the project (if not answered above):

#### Is there documentation on how to use this feature? If so, where?
This is the documentation.
#### In what environments or workflows is this feature supported?
Any
#### In what environments or workflows is this feature explicitly NOT supported (if any)?

#### Supporting links/other PRs/issues:

💔Thank you!
