### PR TITLE
chore: remove duplicate h1

### DIFF
--- a/certificate-manager/webhook-events.mdx
+++ b/certificate-manager/webhook-events.mdx
@@ -5,7 +5,6 @@ description: Smallstep Platform Webhook Events provide observability around cert
 ---
 
 
-# Webhook Events
 Webhook Events allow for real-time logging of SSH sessions, 
 
 certificate creation, and certificate expirations events.


### PR DESCRIPTION
#### Name of feature: Remove duplicate h1

The `title` is already being added to the page as an `<h1>`. This is showing as a duplicate.

https://smallstep.com/docs/certificate-manager/webhook-events/

![CleanShot 2025-01-08 at 14 25 29@2x](https://github.com/user-attachments/assets/b7d26deb-4418-4ad3-b59a-d2aaebc80c58)


