### PR TITLE
Update docker-tls-certificate-authority.mdx

### DIFF
--- a/tutorials/docker-tls-certificate-authority.mdx
+++ b/tutorials/docker-tls-certificate-authority.mdx
@@ -255,7 +255,7 @@ Or visit [https://localhost:8443](https://localhost:8443/) from your browser.
 
 ### Further Reading
 
-- `[step` Documentation](https://smallstep.com/docs/step-cli)
+- [`step` Documentation](https://smallstep.com/docs/step-cli)
 - [Getting Started](https://smallstep.com/docs/step-cli/basic-crypto-operations)
 - [GitHub Repository](https://github.com/smallstep/cli)
 


### PR DESCRIPTION
Fix Further Reading link

#### Name of feature:

Documentation fix

#### Pain or issue this feature alleviates:

Broken link under Further Reading