### PR TITLE
Browser client cert documentation

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -55,7 +55,7 @@
           ]
         },
         {
-          "title": "Configure Endpoints for Smallstep",
+          "title": "Configure Devices for Smallstep",
           "routes": [
               {
                   "title": "Configure Browser Certificates",

--- a/manifest.json
+++ b/manifest.json
@@ -55,6 +55,15 @@
           ]
         },
         {
+          "title": "Configure Endpoints for Smallstep",
+          "routes": [
+              {
+                  "title": "Configure Browser Certificates",
+                  "path": "/tutorials/browser-certificate-setup-guide.mdx"
+              }
+          ]
+        },
+        {
           "title": "Smallstep for WPA-Enterprise Wi-Fi",
           "routes": [
             {

--- a/manifest.json
+++ b/manifest.json
@@ -30,10 +30,6 @@
             {
               "title": "Smallstep API",
               "path": "/platform/smallstep-api.mdx"
-            },
-            {
-              "title": "Smallstep App",
-              "path": "/platform/smallstep-app.mdx"
             }
           ]
         },
@@ -57,6 +53,10 @@
         {
           "title": "Configure Devices for Smallstep",
           "routes": [
+              {
+                "title": "Install the Smallstep App",
+                "path": "/platform/smallstep-app.mdx"
+              },
               {
                   "title": "Configure Browser Certificates",
                   "path": "/tutorials/browser-certificate-setup-guide.mdx"

--- a/platform/smallstep-app.mdx
+++ b/platform/smallstep-app.mdx
@@ -4,11 +4,11 @@ title: The Smallstep App
 html_title: The Smallstep App
 description: This document specifies app download links, system requirements, runtime requirements, file permissions, and telemetry data collected for the Smallstep desktop app.
 ---
-Smallstep ensures that access to financial data, code repositories, PII, and other sensitive resources is only possible from trusted, company-managed devices. 
+Smallstep ensures that access to financial data, code repositories, PII, and other sensitive resources is only possible from trusted devices. 
 
-The Smallstep desktop app is central to that process. It offers a uniform experience for device identity across macOS, Windows, and Linux, and is the foundation for Smallstep's high-assurance device identity attestation workflow, automating the issuance of certificates to devices and configuring the components that depend on these certificates. P.S: The Smallstep app operates differently for Linux. For Linux specific instructions, see [Smallstep Agent for Linux](./smallstep-agent.mdx). 
+The Smallstep desktop app offers a uniform experience for device identity across macOS, Windows, and Linux, and is foundational to Smallstep's high-assurance device attestation workflow, automating the enrollment and delivery of client certificates, and configuring the components that depend on them.
 
-Here's all the necessary info you need to install and use the Smallstep app effectively and consciously.
+The Smallstep app operates differently for Linux. For Linux specific instructions, see [Smallstep Agent for Linux](./smallstep-agent.mdx). 
 
 ## Download
 

--- a/platform/smallstep-app.mdx
+++ b/platform/smallstep-app.mdx
@@ -1,18 +1,19 @@
 ---
+updated_at: April 08, 2025
 title: The Smallstep App
 html_title: The Smallstep App
 description: This document specifies app download links, system requirements, runtime requirements, file permissions, and telemetry data collected for the Smallstep desktop app.
 ---
 Smallstep ensures that access to financial data, code repositories, PII, and other sensitive resources is only possible from trusted, company-managed devices. 
 
-The Smallstep desktop app is central to that process. It offers a uniform experience for device identity across macOS, Windows, and Linux, and is the foundation for Smallstep's high-assurance device identity attestation workflow, automating the issuance of certificates to devices and configuring the components that depend on these certificates. P.S: The Smallstep app operates differently for Linux. For Linux specific instructions, see [Smallstep Agent for Linux](https://smallstep.com/docs/platform/smallstep-agent). 
+The Smallstep desktop app is central to that process. It offers a uniform experience for device identity across macOS, Windows, and Linux, and is the foundation for Smallstep's high-assurance device identity attestation workflow, automating the issuance of certificates to devices and configuring the components that depend on these certificates. P.S: The Smallstep app operates differently for Linux. For Linux specific instructions, see [Smallstep Agent for Linux](./smallstep-agent.mdx). 
 
 Here's all the necessary info you need to install and use the Smallstep app effectively and consciously.
 
 ## Download
 
 <Alert severity="info">
-The Smallstep App includes the <a href="smallstep-agent.mdx">Smallstep Agent</a>,
+The Smallstep App includes the <a href="/docs/platform/smallstep-agent">Smallstep Agent</a>,
 which runs in the background.
 </Alert>
 

--- a/tutorials/browser-certificate-setup-guide.mdx
+++ b/tutorials/browser-certificate-setup-guide.mdx
@@ -9,10 +9,9 @@ description: This tutorial describes how to set up web browsers to access resour
 
 Certificate-based authentication in web browsers
 offers excellent security characteristics, thanks to mutual TLS.
-
 However, the user experience has traditionally been poor,
-with mysterious certificate errors,
-confusing certificate authentication dialogs,
+with mysterious TLS errors,
+confusing certificate selection dialogs,
 and differing behaviors between browsers.
 
 Smallstep addresses these issues
@@ -23,10 +22,16 @@ so the user can have a seamless experience.
 
 Smallstep browser certificates are available for macOS, Windows, and Linux devices.
 
+## Before you begin
+
 Before you begin, make sure:
 
-1. Your devices are [added to Smallstep](https://smallstep.com/docs/platform/enrollment-guide/).
-2. Someone from [our support team](https://support.smallstep.com/kb-tickets/new) has helped you get set up. Your Smallstep team is configured properly for the resource that you are using client certificates to protect.
+1. Your devices are [enrolled into your Smallstep inventory](https://smallstep.com/docs/platform/enrollment-guide/).
+2. Someone from [our support team](https://support.smallstep.com/kb-tickets/new) has helped you get set up. Client certificates can be used in several ways. Confirm that your Smallstep team is configured for the resource that you are using client certificates to protect.
+
+You will need a list of URLs that will require a client certificate on your devices.
+
+These URLs will vary by use case.
 
 ## macOS
 
@@ -167,8 +172,8 @@ For Chrome and Edge, we can use the [`AutoSelectCertificateForUrls`](https://chr
 5. Restart the browser.
 6. Confirm the policy change.
 
-  - In Chrome, check <a href="chrome://policy">chrome://policy</a>.
-  - In Edge, check <a href="edge://policy">edge://policy</a>.
+   - In Chrome, check <a href="chrome://policy">chrome://policy</a>.
+   - In Edge, check <a href="edge://policy">edge://policy</a>.
 
 To test the certificate, restart the browser and visit one your target URLs.
 You should not see any certificate selection dialogs.
@@ -207,6 +212,8 @@ Don't see it? Check that the Smallstep agent is installed correctly.
 
 To test the certificate, restart the browser and visit one your target URLs.
 You should not see any certificate selection dialogs.
+
+### Firefox
 
 #### Client certificate auto-selection
 

--- a/tutorials/browser-certificate-setup-guide.mdx
+++ b/tutorials/browser-certificate-setup-guide.mdx
@@ -1,6 +1,6 @@
 ---
 title: Configure Web Browser Certificates
-updated_at: March 17, 2025
+updated_at: March 20, 2025
 html_title: Configure your web browsers to use Smallstep hardware-bound device identtiy certificates.
 description: This tutorial describes how to set up web browsers to access resources using mutual TLS and Smallstep certificates.
 ---
@@ -32,6 +32,8 @@ For this tutorial, we'll assume you're using Jamf Pro as your MDM.
 The steps are very similar for other MDMs, however.
 
 ### Firefox
+
+#### Client certificate auto-selection
 
 A [configuration profile](https://support.mozilla.org/en-US/kb/customizing-firefox-macos-using-configuration-prof) can be used to set Firefox's certificate preferences
 so that the Smallstep certificate is automatically selected
@@ -77,6 +79,11 @@ when a protected resource is accessed.
 To test the certificate, visit `https://accounts.ca.[team-id].smallstep.com/-/hello-mtls`. You can find your Team ID in [Team Settings](https://smallstep.com/app/?next=/settings/team).
 
 ### Chrome
+
+#### Authority configuration
+
+
+#### Client certificate auto-selection
 
 A [configuration profile](https://support.google.com/chrome/a/answer/9020077?hl=en) can be used to set Chrome's certificate preferences
 so that the Smallstep certificate is automatically selected
@@ -126,17 +133,61 @@ To test the certificate, visit `https://accounts.ca.[team-id].smallstep.com/-/he
 
 ### Safari
 
+#### Authority configuration
+
+Safari will trust CA certificates in Keychain Access, as long as their trust setting for SSL is turned on.
+The easiest way to deploy a trusted CA to a fleet of Apple devices is via MDM.
+
+#### Client certificate auto-selection
+
 Safari relies on the Keychain and system-level certificate trust settings, rather than per-app policies like Chrome and Firefox. Certificate selection in Safari is mostly automatic, but it may prompt the user if multiple matching client certificates exist. Smallstep's agent will set identity preferences as needed.
 
 To test the certificate, visit `https://accounts.ca.[team-id].smallstep.com/-/hello-mtls`. You can find your Team ID in [Team Settings](https://smallstep.com/app/?next=/settings/team).
 
 ## Linux
 
+
 ### Google Chrome
 
-First, we need to establish Root CA trust on the device.
+#### Authority configuration
 
-Next, we can use the [AutoSelectCertificateForUrls](https://chromeenterprise.google/policies/?policy=AutoSelectCertificateForUrls) Chrome policy to automatically select the client certificate without presenting a dialog:
+Since Chrome trusts the Linux system trust store, we need to install the root CA certificate there.
+
+1. Copy your root CA certificate to the trusted location:
+
+   For Debian/Ubuntu:
+
+   ```
+   sudo cp your-root-ca.crt /usr/local/share/ca-certificates/your-root-ca.crt
+   ```
+
+   For RHEL/CentOS/Fedora:
+
+   ```
+   sudo cp your-root-ca.crt /etc/pki/ca-trust/source/anchors/your-root-ca.crt
+   ```
+
+2. Update the system CA store:
+
+   Debian/Ubuntu:
+
+   ```
+   sudo update-ca-certificates
+   ```
+
+   RHEL/CentOS/Fedora:
+
+   ```
+   sudo update-ca-trust
+   ```
+
+3. Restart your web browser
+
+Chrome trusts CA certificates installed in the system CA store.
+
+#### Client certificate auto-selection
+
+We can use the [AutoSelectCertificateForUrls](https://chromeenterprise.google/policies/?policy=AutoSelectCertificateForUrls) Chrome policy to automatically select the client certificate without presenting a dialog:
 1. As root, create a policy file: `/etc/opt/chrome/policies/managed/auto_select_cert.json` 
 2. Add the following content:
 
@@ -161,6 +212,26 @@ Finally, let's verify that the user has a client certificate from the Smallstep 
 1. Run `certutil -d sql:$HOME/.pki/nssdb -L`. You should see `Smallstep Accounts Intermediate CA` in the list.
 2. Restart Chrome, and verify that the client certificate is in <a href="chrome://settings/certificates">Chrome's Certificate Manager</a>
 Don't see it? Check that the Smallstep agent is installed correctly.
+
+To test the certificate, visit `https://accounts.ca.[team-id].smallstep.com/-/hello-mtls`. You can find your Team ID in [Team Settings](https://smallstep.com/app/?next=/settings/team).
+
+### Firefox
+
+#### Authority configuration
+
+Firefox has its own trust store for CAs.
+
+To install the root CA certificate, run:
+
+```
+step certificate install root_ca.crt --firefox
+```
+
+To confirm root CA trust, restart Firefox and visit <a href="about:certificate">about:certificate</a>. Navigate to the Authorities tab. `Smallstep Accounts Intermediate CA` should be listed there.
+
+#### Client certificate auto-selection
+
+Use the <a href="about:certificate">about:certificate</a> URL to see all of the client certificates installed in Firefox's certificate database.
 
 To test the certificate, visit `https://accounts.ca.[team-id].smallstep.com/-/hello-mtls`. You can find your Team ID in [Team Settings](https://smallstep.com/app/?next=/settings/team).
 

--- a/tutorials/browser-certificate-setup-guide.mdx
+++ b/tutorials/browser-certificate-setup-guide.mdx
@@ -1,6 +1,6 @@
 ---
 title: Configure Web Browser Certificates
-updated_at: March 20, 2025
+updated_at: March 26, 2025
 html_title: Configure your web browsers to use Smallstep hardware-bound device identtiy certificates.
 description: This tutorial describes how to set up web browsers to access resources using mutual TLS and Smallstep certificates.
 ---
@@ -9,9 +9,10 @@ description: This tutorial describes how to set up web browsers to access resour
 
 Certificate-based authentication in web browsers
 offers excellent security characteristics, thanks to mutual TLS.
+
 However, the user experience has traditionally been poor,
 with mysterious certificate errors,
-confusing certificate selector dialogs,
+confusing certificate authentication dialogs,
 and differing behaviors between browsers.
 
 Smallstep addresses these issues
@@ -22,9 +23,10 @@ so the user can have a seamless experience.
 
 Smallstep browser certificates are available for macOS, Windows, and Linux devices.
 
-To prepare an device to use browser client certificates from Smallstep:
-1. The device should be [added to Smallstep](https://smallstep.com/docs/platform/enrollment-guide/).
-2. A protected resource that uses browser certificates should be added to Smallstep. This could be a Browser resource, or the Smallstep Device IdP integration (eg. Smallstep for Okta).
+Before you begin, make sure:
+
+1. Your devices are [added to Smallstep](https://smallstep.com/docs/platform/enrollment-guide/).
+2. Someone from [our support team](https://support.smallstep.com/kb-tickets/new) has helped you get set up. Your Smallstep team is configured properly for the resource that you are trying to protect.
 
 ## macOS
 
@@ -32,6 +34,18 @@ For this tutorial, we'll assume you're using Jamf Pro as your MDM.
 The steps are very similar for other MDMs, however.
 
 ### Firefox
+
+#### Authority configuration
+
+Firefox has its own trust store for CAs.
+
+To install the root CA certificate, run:
+
+```
+step certificate install root_ca.crt --firefox
+```
+
+To confirm root CA trust, restart Firefox and visit <a href="about:certificate">about:certificate</a>. Navigate to the Authorities tab. `Smallstep Accounts Intermediate CA` should be listed.
 
 #### Client certificate auto-selection
 
@@ -146,44 +160,20 @@ To test the certificate, visit `https://accounts.ca.[team-id].smallstep.com/-/he
 
 ## Linux
 
-
 ### Google Chrome
 
 #### Authority configuration
 
 Since Chrome trusts the Linux system trust store, we need to install the root CA certificate there.
 
-1. Copy your root CA certificate to the trusted location:
+1. Install your root CA certificate to the trusted location:
 
-   For Debian/Ubuntu:
-
-   ```
-   sudo cp your-root-ca.crt /usr/local/share/ca-certificates/your-root-ca.crt
-   ```
-
-   For RHEL/CentOS/Fedora:
 
    ```
-   sudo cp your-root-ca.crt /etc/pki/ca-trust/source/anchors/your-root-ca.crt
+   sudo step certificate install your-root-ca.crt
    ```
 
-2. Update the system CA store:
-
-   Debian/Ubuntu:
-
-   ```
-   sudo update-ca-certificates
-   ```
-
-   RHEL/CentOS/Fedora:
-
-   ```
-   sudo update-ca-trust
-   ```
-
-3. Restart your web browser
-
-Chrome trusts CA certificates installed in the system CA store.
+2. Restart your web browser
 
 #### Client certificate auto-selection
 

--- a/tutorials/browser-certificate-setup-guide.mdx
+++ b/tutorials/browser-certificate-setup-guide.mdx
@@ -1,6 +1,6 @@
 ---
 title: Configure Web Browser Certificates
-updated_at: April 02, 2025
+updated_at: April 08, 2025
 html_title: Configure your web browsers to use Smallstep hardware-bound device identtiy certificates.
 description: This tutorial describes how to set up web browsers to access resources using mutual TLS and Smallstep certificates.
 ---
@@ -157,6 +157,27 @@ The easiest way to deploy a trusted CA to a fleet of Apple devices is via MDM.
 Safari relies on the Keychain and system-level certificate trust settings, rather than per-app policies like Chrome and Firefox. Certificate selection in Safari is mostly automatic, but it may prompt the user if multiple matching client certificates exist. Smallstep's agent will set identity preferences as needed.
 
 To test the certificate, visit `https://accounts.ca.[team-id].smallstep.com/-/hello-mtls`. You can find your Team ID in [Team Settings](https://smallstep.com/app/?next=/settings/team).
+
+## Windows
+
+### Microsoft Edge and Google Chrome
+
+#### Client certificate auto-selection
+
+1. Confirm that a client certificate has been issued, run `certmgr` from PowerShell.
+   Look inside Certificates - Current User → Personal → Certificates.
+   You should see a certificate issued by `Smallstep Accounts Intermediate CA`.
+
+2. In Chrome, confirm that your certificate is visible in <a href="chrome://settings/certificates">chrome://settings/certificates</a>. If not, restart Chrome.
+
+For Chrome and Edge, we can use the [`AutoSelectCertificateForUrls`](https://chromeenterprise.google/policies/?policy=AutoSelectCertificateForUrls) policy to prevent the certificate selection dialog from appearing.
+
+1. Open the Registry Editor (`regedit`)
+2. Navigate to `HKEY_LOCAL_MACHINE\Software\Policies\Google\Chrome` for Chrome, or `HKEY_CURRENT_USER\SOFTWARE\Policies\Microsoft\Edge` for Edge. If the key you're looking for doesn't exist, you may need to create the `Google` and `Google/Chrome` keys or the `Edge` key.
+3. In the registry path for your browser, create a new String Value named `AutoSelectCertificateForUrls`
+4. Set the value to `["{\"pattern\":\"$URL\",\"filter\":{\"ISSUER\":{\"CN\":\"Smallstep Accounts Intermediate CA\"}}}"]`, substituting `$URL` for the URL you want to use with the Smallstep client certificate.
+5. Restart the browser. In Chrome, visit <a href="chrome://policies">chrome://policies</a> to confirm the policy change.
+6. Visit the URL you want to use the client certificate for. Your certificate should be selected automatically.
 
 ## Linux
 

--- a/tutorials/browser-certificate-setup-guide.mdx
+++ b/tutorials/browser-certificate-setup-guide.mdx
@@ -26,7 +26,7 @@ Smallstep browser certificates are available for macOS, Windows, and Linux devic
 Before you begin, make sure:
 
 1. Your devices are [added to Smallstep](https://smallstep.com/docs/platform/enrollment-guide/).
-2. Someone from [our support team](https://support.smallstep.com/kb-tickets/new) has helped you get set up. Your Smallstep team is configured properly for the resource that you are trying to protect.
+2. Someone from [our support team](https://support.smallstep.com/kb-tickets/new) has helped you get set up. Your Smallstep team is configured properly for the resource that you are using client certificates to protect.
 
 ## macOS
 

--- a/tutorials/browser-certificate-setup-guide.mdx
+++ b/tutorials/browser-certificate-setup-guide.mdx
@@ -1,6 +1,6 @@
 ---
 title: Configure Web Browser Certificates
-updated_at: March 26, 2025
+updated_at: April 02, 2025
 html_title: Configure your web browsers to use Smallstep hardware-bound device identtiy certificates.
 description: This tutorial describes how to set up web browsers to access resources using mutual TLS and Smallstep certificates.
 ---
@@ -223,5 +223,5 @@ To confirm root CA trust, restart Firefox and visit <a href="about:certificate">
 
 Use the <a href="about:certificate">about:certificate</a> URL to see all of the client certificates installed in Firefox's certificate database.
 
-To test the certificate, visit `https://accounts.ca.[team-id].smallstep.com/-/hello-mtls`. You can find your Team ID in [Team Settings](https://smallstep.com/app/?next=/settings/team).
+To test the certificate, visit `https://accounts.[team-id].ca.smallstep.com/-/hello-mtls`. You can find your Team ID in [Team Settings](https://smallstep.com/app/?next=/settings/team).
 

--- a/tutorials/browser-certificate-setup-guide.mdx
+++ b/tutorials/browser-certificate-setup-guide.mdx
@@ -20,10 +20,10 @@ offering simple remediation flows when an error occurs,
 and ensuring that web browers are configured to find client certificates automatically,
 so the user can have a seamless experience.
 
-Smallstep browser certificates are available for macOS, Windows, and Linux endpoints.
+Smallstep browser certificates are available for macOS, Windows, and Linux devices.
 
-To prepare an endpoint to use browser client certificates from Smallstep:
-1. The endpoint should be [added to Smallstep](https://smallstep.com/docs/platform/enrollment-guide/).
+To prepare an device to use browser client certificates from Smallstep:
+1. The device should be [added to Smallstep](https://smallstep.com/docs/platform/enrollment-guide/).
 2. A protected resource that uses browser certificates should be added to Smallstep. This could be a Browser resource, or the Smallstep Device IdP integration (eg. Smallstep for Okta).
 
 ## macOS
@@ -72,9 +72,9 @@ when a protected resource is accessed.
    </plist>
    ```
 5. Upload the plist file to Jamf.
-6. Deploy the configuration profile to your test endpoint.
+6. Deploy the configuration profile to your test device.
 
-To test the certificate, restart Firefox and visit `https://accounts.ca.[team-id].smallstep.com/-/hello-mtls`. You can find your Team ID in [Team Settings](https://smallstep.com/app/?next=/settings/team).
+To test the certificate, visit `https://accounts.ca.[team-id].smallstep.com/-/hello-mtls`. You can find your Team ID in [Team Settings](https://smallstep.com/app/?next=/settings/team).
 
 ### Chrome
 
@@ -119,11 +119,48 @@ when a protected resource is accessed.
    You must add all of your certificate selection preferences into a single managed configuration profile.
 
 5. Upload the plist file to Jamf.
-6. Deploy the configuration profile to your test endpoint.
+6. Deploy the configuration profile to a test device.
+7. On the device, restart Chrome and visit the [policies tab](chrome://policy/) to verify the applied policy.
 
-To test the certificate, restart Firefox and visit `https://accounts.ca.[team-id].smallstep.com/-/hello-mtls`. You can find your Team ID in [Team Settings](https://smallstep.com/app/?next=/settings/team).
+To test the certificate, visit `https://accounts.ca.[team-id].smallstep.com/-/hello-mtls`. You can find your Team ID in [Team Settings](https://smallstep.com/app/?next=/settings/team).
 
 ### Safari
 
 Safari relies on the Keychain and system-level certificate trust settings, rather than per-app policies like Chrome and Firefox. Certificate selection in Safari is mostly automatic, but it may prompt the user if multiple matching client certificates exist. Smallstep's agent will set identity preferences as needed.
+
+To test the certificate, visit `https://accounts.ca.[team-id].smallstep.com/-/hello-mtls`. You can find your Team ID in [Team Settings](https://smallstep.com/app/?next=/settings/team).
+
+## Linux
+
+### Google Chrome
+
+First, we need to establish Root CA trust on the device.
+
+Next, we can use the [AutoSelectCertificateForUrls](https://chromeenterprise.google/policies/?policy=AutoSelectCertificateForUrls) Chrome policy to automatically select the client certificate without presenting a dialog:
+1. As root, create a policy file: `/etc/opt/chrome/policies/managed/auto_select_cert.json` 
+2. Add the following content:
+
+   ```
+   {
+       "AutoSelectCertificateForUrls": ["{\"pattern\":${url},\"filter\":{\"ISSUER\":{\"CN\":\"Smallstep Accounts Intermediate CA\"}}}"]
+   }
+   ```
+
+   Replace `${url}` with the server that requires certificate authentication.
+   For example:
+   
+   ```json
+   {
+       "AutoSelectCertificateForUrls": ["{\"pattern\":\"https://example.id.smallstep.com\",\"filter\":{\"ISSUER\":{\"CN\":\"Smallstep Accounts Intermediate CA\"}}}"]
+   }
+   ```
+
+3. Restart Chrome, and visit the [policies tab](chrome://policy/) to verify the applied policy.
+
+Finally, let's verify that the user has a client certificate from the Smallstep agent.
+1. Run `certutil -d sql:$HOME/.pki/nssdb -L`. You should see `Smallstep Accounts Intermediate CA` in the list.
+2. Restart Chrome, and verify that the client certificate is in <a href="chrome://settings/certificates">Chrome's Certificate Manager</a>
+Don't see it? Check that the Smallstep agent is installed correctly.
+
+To test the certificate, visit `https://accounts.ca.[team-id].smallstep.com/-/hello-mtls`. You can find your Team ID in [Team Settings](https://smallstep.com/app/?next=/settings/team).
 

--- a/tutorials/browser-certificate-setup-guide.mdx
+++ b/tutorials/browser-certificate-setup-guide.mdx
@@ -1,6 +1,6 @@
 ---
 title: Configure Web Browser Certificates
-updated_at: March 11, 2025
+updated_at: March 17, 2025
 html_title: Configure your web browsers to use Smallstep hardware-bound device identtiy certificates.
 description: This tutorial describes how to set up web browsers to access resources using mutual TLS and Smallstep certificates.
 ---
@@ -114,6 +114,10 @@ when a protected resource is accessed.
    Replace `[Server URL]` with the server that requires certificate authentication.
    This field is an [Enterprise policy URL pattern](https://chromeenterprise.google/policies/url-patterns/).
 
+   Note: According to [Understand Chrome policy management](https://support.google.com/chrome/a/answer/9037717),
+   Chrome will *not* merge multiple `AutoSelectCertificateForUrls` policies.
+   You must add all of your certificate selection preferences into a single managed configuration profile.
+
 5. Upload the plist file to Jamf.
 6. Deploy the configuration profile to your test endpoint.
 
@@ -121,6 +125,5 @@ To test the certificate, restart Firefox and visit `https://accounts.ca.[team-id
 
 ### Safari
 
-Safari relies on the Keychain and system-level certificate trust settings, rather than per-app policies like Chrome and Firefox. Certificate selection in Safari is mostly automatic, but it may prompt the user if multiple matching client certificates exist.
-
+Safari relies on the Keychain and system-level certificate trust settings, rather than per-app policies like Chrome and Firefox. Certificate selection in Safari is mostly automatic, but it may prompt the user if multiple matching client certificates exist. Smallstep's agent will set identity preferences as needed.
 

--- a/tutorials/browser-certificate-setup-guide.mdx
+++ b/tutorials/browser-certificate-setup-guide.mdx
@@ -1,0 +1,126 @@
+---
+title: Configure Web Browser Certificates
+updated_at: March 11, 2025
+html_title: Configure your web browsers to use Smallstep hardware-bound device identtiy certificates.
+description: This tutorial describes how to set up web browsers to access resources using mutual TLS and Smallstep certificates.
+---
+
+## Before we begin
+
+Certificate-based authentication in web browsers
+offers excellent security characteristics, thanks to mutual TLS.
+However, the user experience has traditionally been poor,
+with mysterious certificate errors,
+confusing certificate selector dialogs,
+and differing behaviors between browsers.
+
+Smallstep addresses these issues
+by keeping certificates renewed,
+offering simple remediation flows when an error occurs,
+and ensuring that web browers are configured to find client certificates automatically,
+so the user can have a seamless experience.
+
+Smallstep browser certificates are available for macOS, Windows, and Linux endpoints.
+
+To prepare an endpoint to use browser client certificates from Smallstep:
+1. The endpoint should be [added to Smallstep](https://smallstep.com/docs/platform/enrollment-guide/).
+2. A protected resource that uses browser certificates should be added to Smallstep. This could be a Browser resource, or the Smallstep Device IdP integration (eg. Smallstep for Okta).
+
+## macOS
+
+For this tutorial, we'll assume you're using Jamf Pro as your MDM.
+The steps are very similar for other MDMs, however.
+
+### Firefox
+
+A [configuration profile](https://support.mozilla.org/en-US/kb/customizing-firefox-macos-using-configuration-prof) can be used to set Firefox's certificate preferences
+so that the Smallstep certificate is automatically selected
+when a protected resource is accessed.
+
+1. In Jamf, navigate to **Computers > Configuration Profiles**
+2. Create a new Configuration Profile and find the **Application & Custom Settings** > **Upload** page.
+3. For Preference Domain, specify `org.mozilla.firefox`.
+4. Create a plist file called `org.mozilla.firefox.plist`, and populate it with the following:
+
+   ```
+   <?xml version="1.0" encoding="UTF-8"?>
+   <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+   <plist version="1.0">
+     <dict>
+       <key>EnterprisePoliciesEnabled</key>
+       <true/>
+       <key>PayloadDisplayName</key>
+       <string>Firefox ESR Policies</string>
+       <key>PayloadEnabled</key>
+       <true/>
+       <key>PayloadIdentifier</key>
+       <string>org.mozilla.firefox.BCADDC78-843E-4112-936A-DAB8EEEF514C</string>
+       <key>PayloadType</key>
+       <string>org.mozilla.firefox</string>
+       <key>PayloadUUID</key>
+       <string>BCADDC78-843E-4112-936A-DAB8EEEF514C</string>
+       <key>PayloadVersion</key>
+       <integer>1</integer>
+       <key>Preferences</key>
+       <dict>
+         <key>security.default_personal_cert</key>
+         <string>Select Automatically</string>
+         <key>security.osclientcerts.autoload</key>
+         <true/>
+       </dict>
+     </dict>
+   </plist>
+   ```
+5. Upload the plist file to Jamf.
+6. Deploy the configuration profile to your test endpoint.
+
+To test the certificate, restart Firefox and visit `https://accounts.ca.[team-id].smallstep.com/-/hello-mtls`. You can find your Team ID in [Team Settings](https://smallstep.com/app/?next=/settings/team).
+
+### Chrome
+
+A [configuration profile](https://support.google.com/chrome/a/answer/9020077?hl=en) can be used to set Chrome's certificate preferences
+so that the Smallstep certificate is automatically selected
+when a protected resource is accessed.
+
+1. In Jamf, navigate to **Computers > Configuration Profiles**
+2. Create a new Configuration Profile and find the **Application & Custom Settings** > **Upload** page.
+3. For Preference Domain, specify `com.google.Chrome`.
+4. Create a plist file called `com.google.Chrome.plist`, and populate it with the following:
+
+   ```
+   <?xml version="1.0" encoding="UTF-8"?>
+   <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+   <plist version="1.0">
+     <dict>
+       <key>AutoSelectCertificateForUrls</key>
+       <array>
+         <dict>
+           <key>pattern</key>
+           <string>[Server URL]</string>
+           <key>filter</key>
+           <dict>
+              <key>ISSUER</key>
+              <dict>
+                <key>CN</key>
+                <string>Smallstep Accounts Intermediate CA</string>
+              </dict>
+           </dict>
+         </dict>
+       </array>
+     </dict>
+   </plist>
+   ```
+
+   Replace `[Server URL]` with the server that requires certificate authentication.
+   This field is an [Enterprise policy URL pattern](https://chromeenterprise.google/policies/url-patterns/).
+
+5. Upload the plist file to Jamf.
+6. Deploy the configuration profile to your test endpoint.
+
+To test the certificate, restart Firefox and visit `https://accounts.ca.[team-id].smallstep.com/-/hello-mtls`. You can find your Team ID in [Team Settings](https://smallstep.com/app/?next=/settings/team).
+
+### Safari
+
+Safari relies on the Keychain and system-level certificate trust settings, rather than per-app policies like Chrome and Firefox. Certificate selection in Safari is mostly automatic, but it may prompt the user if multiple matching client certificates exist.
+
+

--- a/tutorials/browser-certificate-setup-guide.mdx
+++ b/tutorials/browser-certificate-setup-guide.mdx
@@ -35,18 +35,6 @@ The steps are very similar for other MDMs, however.
 
 ### Firefox
 
-#### Authority configuration
-
-Firefox has its own trust store for CAs.
-
-To install the root CA certificate, run:
-
-```
-step certificate install root_ca.crt --firefox
-```
-
-To confirm root CA trust, restart Firefox and visit <a href="about:certificate">about:certificate</a>. Navigate to the Authorities tab. `Smallstep Accounts Intermediate CA` should be listed.
-
 #### Client certificate auto-selection
 
 A [configuration profile](https://support.mozilla.org/en-US/kb/customizing-firefox-macos-using-configuration-prof) can be used to set Firefox's certificate preferences
@@ -90,12 +78,9 @@ when a protected resource is accessed.
 5. Upload the plist file to Jamf.
 6. Deploy the configuration profile to your test device.
 
-To test the certificate, visit `https://accounts.ca.[team-id].smallstep.com/-/hello-mtls`. You can find your Team ID in [Team Settings](https://smallstep.com/app/?next=/settings/team).
+To test the certificate, restart the browser and visit one your target URLs.
 
 ### Chrome
-
-#### Authority configuration
-
 
 #### Client certificate auto-selection
 
@@ -143,20 +128,15 @@ when a protected resource is accessed.
 6. Deploy the configuration profile to a test device.
 7. On the device, restart Chrome and visit the [policies tab](chrome://policy/) to verify the applied policy.
 
-To test the certificate, visit `https://accounts.ca.[team-id].smallstep.com/-/hello-mtls`. You can find your Team ID in [Team Settings](https://smallstep.com/app/?next=/settings/team).
+To test the certificate, restart the browser and visit one your target URLs.
 
 ### Safari
-
-#### Authority configuration
-
-Safari will trust CA certificates in Keychain Access, as long as their trust setting for SSL is turned on.
-The easiest way to deploy a trusted CA to a fleet of Apple devices is via MDM.
 
 #### Client certificate auto-selection
 
 Safari relies on the Keychain and system-level certificate trust settings, rather than per-app policies like Chrome and Firefox. Certificate selection in Safari is mostly automatic, but it may prompt the user if multiple matching client certificates exist. Smallstep's agent will set identity preferences as needed.
 
-To test the certificate, visit `https://accounts.ca.[team-id].smallstep.com/-/hello-mtls`. You can find your Team ID in [Team Settings](https://smallstep.com/app/?next=/settings/team).
+To test the certificate, restart the browser and visit one your target URLs.
 
 ## Windows
 
@@ -168,33 +148,34 @@ To test the certificate, visit `https://accounts.ca.[team-id].smallstep.com/-/he
    Look inside Certificates - Current User → Personal → Certificates.
    You should see a certificate issued by `Smallstep Accounts Intermediate CA`.
 
-2. In Chrome, confirm that your certificate is visible in <a href="chrome://settings/certificates">chrome://settings/certificates</a>. If not, restart Chrome.
+2. Confirm your client certificate is visible in your browser. If not, restart the browser.
+
+   - In Chrome, check <a href="chrome://settings/certificates">chrome://settings/certificates</a>.
+   - In Edge, check <a href="edge://settings/privacy/securitySubPage">edge://settings/privacy/securitySubPage</a> and choose "Manage certificates".
 
 For Chrome and Edge, we can use the [`AutoSelectCertificateForUrls`](https://chromeenterprise.google/policies/?policy=AutoSelectCertificateForUrls) policy to prevent the certificate selection dialog from appearing.
 
 1. Open the Registry Editor (`regedit`)
-2. Navigate to `HKEY_LOCAL_MACHINE\Software\Policies\Google\Chrome` for Chrome, or `HKEY_CURRENT_USER\SOFTWARE\Policies\Microsoft\Edge` for Edge. If the key you're looking for doesn't exist, you may need to create the `Google` and `Google/Chrome` keys or the `Edge` key.
+2. Navigate to to the key for your browser.
+
+   - For Chrome, visit `HKEY_LOCAL_MACHINE\Software\Policies\Google\Chrome`
+   - For Edge, visit `HKEY_CURRENT_USER\SOFTWARE\Policies\Microsoft\Edge`
+   - If the key you're looking for doesn't exist, you may need to create the `Google` and `Google/Chrome` keys or the `Edge` key.
+
 3. In the registry path for your browser, create a new String Value named `AutoSelectCertificateForUrls`
 4. Set the value to `["{\"pattern\":\"$URL\",\"filter\":{\"ISSUER\":{\"CN\":\"Smallstep Accounts Intermediate CA\"}}}"]`, substituting `$URL` for the URL you want to use with the Smallstep client certificate.
-5. Restart the browser. In Chrome, visit <a href="chrome://policies">chrome://policies</a> to confirm the policy change.
-6. Visit the URL you want to use the client certificate for. Your certificate should be selected automatically.
+5. Restart the browser.
+6. Confirm the policy change.
+
+  - In Chrome, check <a href="chrome://policy">chrome://policy</a>.
+  - In Edge, check <a href="edge://policy">edge://policy</a>.
+
+To test the certificate, restart the browser and visit one your target URLs.
+You should not see any certificate selection dialogs.
 
 ## Linux
 
 ### Google Chrome
-
-#### Authority configuration
-
-Since Chrome trusts the Linux system trust store, we need to install the root CA certificate there.
-
-1. Install your root CA certificate to the trusted location:
-
-
-   ```
-   sudo step certificate install your-root-ca.crt
-   ```
-
-2. Restart your web browser
 
 #### Client certificate auto-selection
 
@@ -217,32 +198,20 @@ We can use the [AutoSelectCertificateForUrls](https://chromeenterprise.google/po
    }
    ```
 
-3. Restart Chrome, and visit the [policies tab](chrome://policy/) to verify the applied policy.
+3. Restart Chrome, and visit the [policies tab](chrome://policy) to verify the applied policy.
 
 Finally, let's verify that the user has a client certificate from the Smallstep agent.
-1. Run `certutil -d sql:$HOME/.pki/nssdb -L`. You should see `Smallstep Accounts Intermediate CA` in the list.
-2. Restart Chrome, and verify that the client certificate is in <a href="chrome://settings/certificates">Chrome's Certificate Manager</a>
+
+Restart Chrome, and verify that the client certificate is in <a href="chrome://settings/certificates">Chrome's Certificate Manager</a>
 Don't see it? Check that the Smallstep agent is installed correctly.
 
-To test the certificate, visit `https://accounts.ca.[team-id].smallstep.com/-/hello-mtls`. You can find your Team ID in [Team Settings](https://smallstep.com/app/?next=/settings/team).
-
-### Firefox
-
-#### Authority configuration
-
-Firefox has its own trust store for CAs.
-
-To install the root CA certificate, run:
-
-```
-step certificate install root_ca.crt --firefox
-```
-
-To confirm root CA trust, restart Firefox and visit <a href="about:certificate">about:certificate</a>. Navigate to the Authorities tab. `Smallstep Accounts Intermediate CA` should be listed there.
+To test the certificate, restart the browser and visit one your target URLs.
+You should not see any certificate selection dialogs.
 
 #### Client certificate auto-selection
 
 Use the <a href="about:certificate">about:certificate</a> URL to see all of the client certificates installed in Firefox's certificate database.
 
-To test the certificate, visit `https://accounts.[team-id].ca.smallstep.com/-/hello-mtls`. You can find your Team ID in [Team Settings](https://smallstep.com/app/?next=/settings/team).
+To test the certificate, restart the browser and visit one your target URLs.
+You should not see any certificate selection dialogs.
 

--- a/tutorials/browser-certificate-setup-guide.mdx
+++ b/tutorials/browser-certificate-setup-guide.mdx
@@ -1,6 +1,6 @@
 ---
 title: Configure Web Browser Certificates
-updated_at: April 08, 2025
+updated_at: April 09, 2025
 html_title: Configure your web browsers to use Smallstep hardware-bound device identtiy certificates.
 description: This tutorial describes how to set up web browsers to access resources using mutual TLS and Smallstep certificates.
 ---
@@ -113,7 +113,7 @@ when a protected resource is accessed.
               <key>ISSUER</key>
               <dict>
                 <key>CN</key>
-                <string>Smallstep Accounts Intermediate CA</string>
+                <string>Smallstep [Team Slug] Accounts Intermediate CA</string>
               </dict>
            </dict>
          </dict>
@@ -123,6 +123,7 @@ when a protected resource is accessed.
    ```
 
    Replace `[Server URL]` with the server that requires certificate authentication.
+   Replace `[Team Slug]` with your Smallstep team slug.
    This field is an [Enterprise policy URL pattern](https://chromeenterprise.google/policies/url-patterns/).
 
    Note: According to [Understand Chrome policy management](https://support.google.com/chrome/a/answer/9037717),
@@ -151,7 +152,7 @@ To test the certificate, restart the browser and visit one your target URLs.
 
 1. Confirm that a client certificate has been issued, run `certmgr` from PowerShell.
    Look inside Certificates - Current User → Personal → Certificates.
-   You should see a certificate issued by `Smallstep Accounts Intermediate CA`.
+   You should see a certificate issued by a Smallstep Accounts Intermediate CA.
 
 2. Confirm your client certificate is visible in your browser. If not, restart the browser.
 
@@ -168,7 +169,7 @@ For Chrome and Edge, we can use the [`AutoSelectCertificateForUrls`](https://chr
    - If the key you're looking for doesn't exist, you may need to create the `Google` and `Google/Chrome` keys or the `Edge` key.
 
 3. In the registry path for your browser, create a new String Value named `AutoSelectCertificateForUrls`
-4. Set the value to `["{\"pattern\":\"$URL\",\"filter\":{\"ISSUER\":{\"CN\":\"Smallstep Accounts Intermediate CA\"}}}"]`, substituting `$URL` for the URL you want to use with the Smallstep client certificate.
+4. Set the value to `["{\"pattern\":\"$URL\",\"filter\":{\"ISSUER\":{\"CN\":\"Smallstep $TEAM Accounts Intermediate CA\"}}}"]`, substituting `$URL` for the URL you want to use with the Smallstep client certificate, and `$TEAM` for your Smallstep team slug.
 5. Restart the browser.
 6. Confirm the policy change.
 
@@ -190,16 +191,17 @@ We can use the [AutoSelectCertificateForUrls](https://chromeenterprise.google/po
 
    ```
    {
-       "AutoSelectCertificateForUrls": ["{\"pattern\":${url},\"filter\":{\"ISSUER\":{\"CN\":\"Smallstep Accounts Intermediate CA\"}}}"]
+       "AutoSelectCertificateForUrls": ["{\"pattern\":\"$URL\",\"filter\":{\"ISSUER\":{\"CN\":\"Smallstep $TEAM Accounts Intermediate CA\"}}}"]
    }
    ```
 
-   Replace `${url}` with the server that requires certificate authentication.
+   Replace `$URL` with the server that requires certificate authentication.
+   Replace `$TEAM` with your Smallstep team slug.
    For example:
    
    ```json
    {
-       "AutoSelectCertificateForUrls": ["{\"pattern\":\"https://example.id.smallstep.com\",\"filter\":{\"ISSUER\":{\"CN\":\"Smallstep Accounts Intermediate CA\"}}}"]
+       "AutoSelectCertificateForUrls": ["{\"pattern\":\"https://example.id.smallstep.com\",\"filter\":{\"ISSUER\":{\"CN\":\"Smallstep example Accounts Intermediate CA\"}}}"]
    }
    ```
 


### PR DESCRIPTION
- [x] Need new instructions for setting up the Browser resource
- [x] Key protection for Linux browsers needs to be set to None for the Browser account. 
- [x] Is the agent required? Yes, for now.
- [ ] Should we add `step-agent-plugin doctor` instructions for troubleshooting?

## for macOS

- [x] Review FIrefox & Chrome instructions
- [ ] Clarify what the agent does with regard to Keychain identity preferences?

## for Linux

- [ ] Add Firefox details

## for Windows

- [x] add Chrome & Edge


### Not relevant anymore

-  [ ] Which root CA should clients trust? The Accounts CA? Why not the workloads CA?
 - [ ] [Yee's doc](https://www.notion.so/smallstep/Chrome-browser-Client-Certificate-on-Linux-1a7d17a9124980f3a03aef5232715706?pvs=4#1a7d17a91249801d9f85c8146598ecd6) instructs the user to check the agent log to find the path to the root CA certificate, then to add the root to the trust store using `step certificate install`. What's a simpler and more reliable way to find the path to the CA certificate?
- [ ] Would be nice to have a solution for testing the client cert that doesn't require adding CA trust — can we use a Let's Encrypt endpoint for this?
