### PR TITLE
Basic Certificate Authority Operations: specify config nesting

### DIFF
--- a/step-ca/basic-certificate-authority-operations.mdx
+++ b/step-ca/basic-certificate-authority-operations.mdx
@@ -193,7 +193,7 @@ $ step ca certificate localhost localhost.crt localhost.key --not-after=5m
 $ step ca certificate localhost localhost.crt localhost.key --not-before=5m --not-after=240h
 ```
 
-Note that default maximum certificate duration is 24 hours. To adjust the global default, minimum, and maximum certificate durations for your CA, add a `claims` section to the `$(step path)/config/ca.json` configuration file, under `"authority"`, with the following keys:
+Note that default maximum certificate duration is 24 hours. To adjust the global default, minimum, and maximum certificate durations for your CA, add a `claims` section to the `$(step path)/config/ca.json` configuration file, nested under `"authority"`, with the following keys:
 
 ```json
 "claims": {


### PR DESCRIPTION
<!---
Please provide answers in the spaces below each prompt, where applicable.
Not every PR requires responses for each prompt.
Use your discretion.
-->
#### Name of feature:

Documentation change. Consider making a separate PR template for the docs repo, since this template is clearly written with code in mind.

#### Pain or issue this feature alleviates:

The term "under" is overloaded. Sometimes it means "nested within", and sometimes it means "as the next section after this one".

#### Why is this important to the project (if not answered above):

This small change reduces ambiguity.

#### Is there documentation on how to use this feature? If so, where?

It's not a feature, it's a documentation change. See above.

#### In what environments or workflows is this feature supported?

I really should have just removed this template instead of filling it out, but I'm a new contributor to this project and don't know if you folks are tight-a**es about submissions being properly formatted. probably not, since this is the template for your docs repo, but you never know.

Also, I hope that reading through this helps encourage you to make a docs-specific PR template. Seriously, I spent more time writing out this PR than on my one-word change to the actual content.

#### In what environments or workflows is this feature explicitly NOT supported (if any)?

This workflow is not supported on Neptune, Uranus, or any of the moons of Jupiter or Saturn, excepting Enceladus.

#### Supporting links/other PRs/issues:

N/A (no snark here, this is a good section that belongs in the new docs PR template I hope y'all make).

> 💔Thank you!

Aww, you're welcome!
