### PR TITLE
[CON-301] Use deb822 source format for Debian & Ubuntu installs

### DIFF
--- a/platform/smallstep-agent.mdx
+++ b/platform/smallstep-agent.mdx
@@ -1,5 +1,5 @@
 ---
-updated_at: November 06, 2025
+updated_at: December 05, 2025
 title: Smallstep Agent for Linux
 html_title: Smallstep Agent for Device Management Guide
 description: Deploy and configure Smallstep Agent on Linux. Automated device identity management and certificate renewal for enterprise Linux fleets.
@@ -118,17 +118,22 @@ curl -fsSL https://packages.smallstep.com/scripts/smallstep-agent-install.sh | s
 ### Debian
 
 1. In the Terminal, install dependencies:
-    
+
     ```bash
     sudo apt-get update && sudo apt-get install -y --no-install-recommends curl gpg ca-certificates
     ```
-    
+
 2. Add our package repository to your system:
-    
+
     ```bash
-    sudo curl -fsSL https://packages.smallstep.com/keys/apt/repo-signing-key.gpg -o /etc/apt/trusted.gpg.d/smallstep.asc && \
-        echo 'deb [signed-by=/etc/apt/trusted.gpg.d/smallstep.asc] https://pkgs.infra.smallstep.com/stable/debian debs main' \
-        | sudo tee /etc/apt/sources.list.d/smallstep.list
+    sudo curl -fsSL https://packages.smallstep.com/keys/apt/repo-signing-key.gpg -o /etc/apt/keyrings/smallstep.asc
+    cat << EOF | sudo tee /etc/apt/sources.list.d/smallstep.sources
+    Types: deb
+    URIs: https://pkgs.infra.smallstep.com/stable/debian
+    Suites: debs
+    Components: main
+    Signed-By: /etc/apt/keyrings/smallstep.asc
+    EOF
     ```
     
 3. Install the Smallstep agent:
@@ -154,18 +159,23 @@ curl -fsSL https://packages.smallstep.com/scripts/smallstep-agent-install.sh | s
 ### Ubuntu
 
 1. In the Terminal, install dependencies:
-    
+
     ```bash
     DEBIAN_FRONTEND=noninteractive
     sudo apt-get update && sudo apt-get install -y --no-install-recommends curl gpg ca-certificates
     ```
-    
+
 2. Add our package repository to your system:
-    
+
     ```bash
-    sudo curl -fsSL https://packages.smallstep.com/keys/apt/repo-signing-key.gpg -o /etc/apt/trusted.gpg.d/smallstep.asc && \
-        echo 'deb [signed-by=/etc/apt/trusted.gpg.d/smallstep.asc] https://packages.smallstep.com/stable/debian debs main' \
-        | sudo tee /etc/apt/sources.list.d/smallstep.list
+    sudo curl -fsSL https://packages.smallstep.com/keys/apt/repo-signing-key.gpg -o /etc/apt/keyrings/smallstep.asc
+    cat << EOF | sudo tee /etc/apt/sources.list.d/smallstep.sources
+    Types: deb
+    URIs: https://packages.smallstep.com/stable/debian
+    Suites: debs
+    Components: main
+    Signed-By: /etc/apt/keyrings/smallstep.asc
+    EOF
     ```
     
 3. Install the Smallstep agent

--- a/step-ca/installation.mdx
+++ b/step-ca/installation.mdx
@@ -1,5 +1,5 @@
 ---
-updated_at: September 18, 2025
+updated_at: December 05, 2025
 title: Install step-ca
 html_title: Install step-ca Certificate Authority Guide
 description: Install step-ca certificate authority on any platform. Quick deployment guide for private PKI infrastructure with comprehensive setup instructions.
@@ -88,10 +88,15 @@ To uninstall, run `scoop uninstall`, then remove the configuration directory `$H
 To add Smallstep as a source and install the `step-cli` and `step-ca` packages on Debian or Ubuntu distributions, run the following as `root`:
 
 ```
-apt-get update && apt-get install -y --no-install-recommends curl vim gpg ca-certificates
-curl -fsSL https://packages.smallstep.com/keys/apt/repo-signing-key.gpg -o /etc/apt/trusted.gpg.d/smallstep.asc && \
-    echo 'deb [signed-by=/etc/apt/trusted.gpg.d/smallstep.asc] https://packages.smallstep.com/stable/debian debs main' \
-    | tee /etc/apt/sources.list.d/smallstep.list
+apt-get update && apt-get install -y --no-install-recommends curl gpg ca-certificates
+curl -fsSL https://packages.smallstep.com/keys/apt/repo-signing-key.gpg -o /etc/apt/keyrings/smallstep.asc
+cat << EOF > /etc/apt/sources.list.d/smallstep.sources
+Types: deb
+URIs: https://packages.smallstep.com/stable/debian
+Suites: debs
+Components: main
+Signed-By: /etc/apt/keyrings/smallstep.asc
+EOF
 apt-get update && apt-get -y install step-cli step-ca
 ```
 

--- a/step-cli/installation.mdx
+++ b/step-cli/installation.mdx
@@ -1,5 +1,5 @@
 ---
-updated_at: September 17, 2025
+updated_at: December 05, 2025
 title: Install step
 html_title: Install Step CLI on Any Platform Guide
 description: Install step CLI on any platform. Quick setup instructions for the command-line tool for certificates and cryptography with easy installation.
@@ -50,10 +50,15 @@ To uninstall, run `brew uninstall step` and remove the `$HOME/.step` configurati
 To add Smallstep as a source and install the `step-cli` package on Debian or Ubuntu distributions, run the following as `root`:
 
 ```
-apt-get update && apt-get install -y --no-install-recommends curl vim gpg ca-certificates
-curl -fsSL https://packages.smallstep.com/keys/apt/repo-signing-key.gpg -o /etc/apt/trusted.gpg.d/smallstep.asc && \
-    echo 'deb [signed-by=/etc/apt/trusted.gpg.d/smallstep.asc] https://packages.smallstep.com/stable/debian debs main' \
-    | tee /etc/apt/sources.list.d/smallstep.list
+apt-get update && apt-get install -y --no-install-recommends curl gpg ca-certificates
+curl -fsSL https://packages.smallstep.com/keys/apt/repo-signing-key.gpg -o /etc/apt/keyrings/smallstep.asc
+cat << EOF > /etc/apt/sources.list.d/smallstep.sources
+Types: deb
+URIs: https://packages.smallstep.com/stable/debian
+Suites: debs
+Components: main
+Signed-By: /etc/apt/keyrings/smallstep.asc
+EOF
 apt-get update && apt-get -y install step-cli
 ```
 


### PR DESCRIPTION
The deb822 format for describing a package source has become the default in both Debian and Ubuntu. The new format has been available since Ubuntu 22.04 and Debian 9.

Closes #468 