### PR TITLE
fix: remove duplicate heading

### DIFF
--- a/README.mdx
+++ b/README.mdx
@@ -2,9 +2,6 @@
 disableSidebar: true
 ---
 
-<div className="text-center">
-  # Documentation
-</div>
 <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-spacing-6">
   <IndexCard
     className="text-blue-500"


### PR DESCRIPTION
The `<h1>` is automatically grabbed from the `front_matter` or the `title` defined in `manifest.json`.

This is resulting in a duplication of the heading.

<img width="2722" height="1748" alt="image" src="https://github.com/user-attachments/assets/1383237a-120d-4010-9b05-df1fc859e1b1" />


Thank you!
