### PR TITLE
Use package repository URLs for agent downloads

### DIFF
--- a/platform/smallstep-agent.mdx
+++ b/platform/smallstep-agent.mdx
@@ -147,7 +147,7 @@ curl -fsSL https://packages.smallstep.com/scripts/smallstep-agent-install.sh | s
     sudo curl -fsSL https://packages.smallstep.com/keys/apt/repo-signing-key.gpg -o /etc/apt/keyrings/smallstep.asc
     cat << EOF | sudo tee /etc/apt/sources.list.d/smallstep.sources
     Types: deb
-    URIs: https://pkgs.infra.smallstep.com/stable/debian
+    URIs: https://packages.smallstep.com/stable/debian
     Suites: debs
     Components: main
     Signed-By: /etc/apt/keyrings/smallstep.asc

--- a/platform/smallstep-agent.mdx
+++ b/platform/smallstep-agent.mdx
@@ -396,9 +396,9 @@ To uninstall the Smallstep Agent from a macOS system:
 
 ## Manual install
 
-1. Download the agent installer from the [Smallstep releases page](https://github.com/smallstep/step-agent-plugin/releases):
-   - For most systems: `step-agent-plugin_amd64_<version>.msi`
-   - For ARM64 systems: `step-agent-plugin_arm64_<version>.msi`
+1. Download the agent installer:
+   - For most systems: [step-agent-plugin_amd64_latest.msi](https://packages.smallstep.com/stable/windows/step-agent-plugin_amd64_latest.msi)
+   - For ARM64 systems: [step-agent-plugin_arm64_latest.msi](https://packages.smallstep.com/stable/windows/step-agent-plugin_arm64_latest.msi)
 
 2. Install the agent silently:
 

--- a/platform/smallstep-app.mdx
+++ b/platform/smallstep-app.mdx
@@ -19,7 +19,23 @@ On macOS and Windows, the Smallstep Agent includes an optional desktop app UI fo
 The agent runs as a background service on all platforms.
 </Alert>
 
-Installers for macOS, Windows and Linux can be downloaded from [GitHub releases](https://github.com/smallstep/step-agent-plugin/releases). Releases are signed with, and can be verified, by cosign.
+Installers for macOS can be downloaded from [GitHub releases](https://github.com/smallstep/step-agent-plugin/releases). Releases are signed with, and can be verified, by cosign.
+
+Windows installers are available from the Smallstep package repository:
+
+| Architecture | MSI |
+|---|---|
+| amd64 | [step-agent-plugin_amd64_latest.msi](https://packages.smallstep.com/stable/windows/step-agent-plugin_amd64_latest.msi) |
+| arm64 | [step-agent-plugin_arm64_latest.msi](https://packages.smallstep.com/stable/windows/step-agent-plugin_arm64_latest.msi) |
+
+Linux packages are available from the Smallstep package repository:
+
+| Architecture | DEB | RPM |
+|---|---|---|
+| amd64 / x86_64 | [step-agent-plugin_amd64_latest.deb](https://packages.smallstep.com/stable/linux/step-agent-plugin_amd64_latest.deb) | [step-agent-plugin_x86_64_latest.rpm](https://packages.smallstep.com/stable/linux/step-agent-plugin_x86_64_latest.rpm) |
+| arm64 / aarch64 | [step-agent-plugin_arm64_latest.deb](https://packages.smallstep.com/stable/linux/step-agent-plugin_arm64_latest.deb) | [step-agent-plugin_aarch64_latest.rpm](https://packages.smallstep.com/stable/linux/step-agent-plugin_aarch64_latest.rpm) |
+
+For Linux installation instructions, see [Deploy the Agent](./smallstep-agent.mdx#linux-installation).
 
 ## System requirements
 

--- a/platform/smallstep-app.mdx
+++ b/platform/smallstep-app.mdx
@@ -21,19 +21,14 @@ The agent runs as a background service on all platforms.
 
 Installers for macOS can be downloaded from [GitHub releases](https://github.com/smallstep/step-agent-plugin/releases). Releases are signed with, and can be verified, by cosign.
 
-Windows installers are available from the Smallstep package repository:
+Windows and Linux packages are available from the Smallstep package repository:
 
-| Architecture | MSI |
-|---|---|
-| amd64 | [step-agent-plugin_amd64_latest.msi](https://packages.smallstep.com/stable/windows/step-agent-plugin_amd64_latest.msi) |
-| arm64 | [step-agent-plugin_arm64_latest.msi](https://packages.smallstep.com/stable/windows/step-agent-plugin_arm64_latest.msi) |
-
-Linux packages are available from the Smallstep package repository:
-
-| Architecture | DEB | RPM |
-|---|---|---|
-| amd64 / x86_64 | [step-agent-plugin_amd64_latest.deb](https://packages.smallstep.com/stable/linux/step-agent-plugin_amd64_latest.deb) | [step-agent-plugin_x86_64_latest.rpm](https://packages.smallstep.com/stable/linux/step-agent-plugin_x86_64_latest.rpm) |
-| arm64 / aarch64 | [step-agent-plugin_arm64_latest.deb](https://packages.smallstep.com/stable/linux/step-agent-plugin_arm64_latest.deb) | [step-agent-plugin_aarch64_latest.rpm](https://packages.smallstep.com/stable/linux/step-agent-plugin_aarch64_latest.rpm) |
+- https://packages.smallstep.com/stable/windows/step-agent-plugin_amd64_latest.msi
+- https://packages.smallstep.com/stable/windows/step-agent-plugin_arm64_latest.msi
+- https://packages.smallstep.com/stable/linux/step-agent-plugin_amd64_latest.deb
+- https://packages.smallstep.com/stable/linux/step-agent-plugin_arm64_latest.deb
+- https://packages.smallstep.com/stable/linux/step-agent-plugin_x86_64_latest.rpm
+- https://packages.smallstep.com/stable/linux/step-agent-plugin_aarch64_latest.rpm
 
 For Linux installation instructions, see [Deploy the Agent](./smallstep-agent.mdx#linux-installation).
 


### PR DESCRIPTION
## Summary
- Replace GitHub releases links with direct download URLs from `packages.smallstep.com` for Windows (MSI) and Linux (DEB/RPM) agent packages
- macOS downloads still point to GitHub releases
- Updated both `platform/smallstep-app.mdx` (download section) and `platform/smallstep-agent.mdx` (Windows manual install)

## Test plan
- [ ] Verify all package URLs resolve (they return 307 redirects to GCS storage)
- [ ] Preview the rendered tables in both pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)