### PR TITLE
Drop path filters from Vale Prose Lint workflow

### DIFF
--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -3,17 +3,7 @@ name: Vale Prose Lint
 on:
   push:
     branches: [main]
-    paths:
-      - '**.mdx'
-      - '**.md'
-      - '.vale.ini'
-      - '.vale/**'
   pull_request:
-    paths:
-      - '**.mdx'
-      - '**.md'
-      - '.vale.ini'
-      - '.vale/**'
 
 jobs:
   prose:


### PR DESCRIPTION
## Summary

- `Lint Prose` is a required status check on `main`, but the workflow's path filters (`**.mdx`, `**.md`, `.vale.ini`, `.vale/**`) skip it on PRs that don't touch those paths.
- When the workflow is skipped, the required check sits in "Expected — Waiting for status to be reported" forever, blocking the PR (see #512).
- Drop the path filters so Vale runs on every PR and the required check always reports. Vale is fast and a no-op when prose files don't change.

## Test plan

- [x] This PR itself should be the first test: it touches no `.md`/`.mdx`/Vale config, so under the old filters Vale would skip; with the filters removed, the `Lint Prose` check should run and pass.