### PR TITLE
Support SCEP automatic profile redistribution in Iru tutorial

### DIFF
--- a/tutorials/connect-iru-to-smallstep.mdx
+++ b/tutorials/connect-iru-to-smallstep.mdx
@@ -176,8 +176,6 @@ The Smallstep Agent requires configuration settings to connect to your Smallstep
 
     Replace `YOUR-TEAM-SLUG` with your actual team slug from Smallstep.
 
-    Leave `$BLUEPRINT_ID` as-is; Iru replaces it with the assigned Blueprint's ID when it deploys the profile. The `ou` and `l` values in the `Certificate` URI must match the `OU` and `L` components of the SCEP profile's Subject, which is why both library items must be assigned to the same Blueprint.
-
 7. Choose **Save**
 
 #### Configure Login Items (macOS)

--- a/tutorials/connect-iru-to-smallstep.mdx
+++ b/tutorials/connect-iru-to-smallstep.mdx
@@ -1,5 +1,5 @@
 ---
-updated_at: July 14, 2026
+updated_at: July 16, 2026
 title: Connect Iru (Kandji) to Smallstep
 html_title: Integrate Iru (Kandji) with Smallstep Tutorial
 description: Integrate Iru (Kandji) with Smallstep for Apple device security. Complete guide for enforcing device trust in macOS environments.
@@ -95,7 +95,7 @@ Keep this page open or save these values temporarily — you'll need them for th
     - **URL**: Paste the SCEP URL from the previous step
     - **Challenge**: Paste the SCEP Challenge from the previous step
     - **Fingerprint**: Paste the Root Certificate Fingerprint from the previous step
-    - **Subject**: `CN=step-agent-bootstrap`
+    - **Subject**: `CN=$PROFILE_UUID,OU=$BLUEPRINT_ID,L=step-agent-bootstrap`
     - Enable **Subject Alternative Names (SAN)**:
       - Key: `Uniform Resource Identifier`
       - Value: `deviceid:$DEVICE_ID`
@@ -106,23 +106,7 @@ Keep this page open or save these values temporarily — you'll need them for th
     - Enable **Automatic profile redistribution**, and set the number of days before certificate expiration when Iru should redistribute the profile (Iru defaults to 30 days). This is what lets the agent's enrollment certificate renew before it expires.
 7. Choose **Save**
 
-When automatic profile redistribution is enabled, Iru appends the SCEP library item's UUID (its `$PROFILE_UUID` value) to the Subject on every request. The Common Name of the issued certificate will be `step-agent-bootstrap <uuid>` (with a single space before the UUID) rather than `step-agent-bootstrap` alone. The agent configuration below must reference this full name.
-
-### Copy the SCEP Library Item UUID
-
-The agent configuration in the next section requires the UUID of the SCEP library item you just created, so the SCEP library item must exist before you create the agent's Custom Profile.
-
-The UUID is the last path segment of the library item's URL in your browser's address bar:
-
-```
-https://<your-tenant>.iru.com/library/scep/<UUID>
-```
-
-Copy the UUID and save it temporarily. You'll need it when configuring the agent settings below.
-
-<Aside>
-Deleting and recreating the SCEP library item generates a new UUID. That breaks the Smallstep Agent on every enrolled device until you update the agent configuration to match the new UUID.
-</Aside>
+A note on the Subject: with automatic profile redistribution enabled, Iru puts the SCEP profile's UUID in the Common Name, so the CN isn't a stable way to identify the certificate. The other two components give the agent stable values to search on instead. Iru replaces `$BLUEPRINT_ID` with the ID of the assigned Blueprint, and `L=step-agent-bootstrap` is a fixed marker value. The agent configuration below looks up the certificate by these two fields.
 
 ## Install the Smallstep Agent
 
@@ -145,15 +129,13 @@ There are two ways to install the agent:
 
 #### Configure the Agent Settings
 
-The Smallstep Agent requires configuration settings to connect to your Smallstep team. Deploy these via a Custom Profile.
-
-The configuration includes the UUID of the SCEP library item, so you must [create the SCEP library item](#create-a-scep-profile-in-iru) and copy its UUID before creating this profile.
+The Smallstep Agent requires configuration settings to connect to your Smallstep team. Deploy these via a Custom Profile:
 
 1. In the Smallstep console, choose ⚙️ **Settings** and temporarily save the **Team Slug** value
 2. In the Iru sidebar, choose **Library**
 3. Choose **Add Library Item**, then select **Custom Profile**, and click **Add and Configure**
 4. Set a title (e.g., `Smallstep Agent Configuration`)
-5. Under **Assignment**, choose your desired Blueprint (should match the agent installation scope)
+5. Under **Assignment**, choose the same Blueprint you assigned to the SCEP profile. This is required: Iru renders `$BLUEPRINT_ID` in both library items, and the values only match when both are assigned to the same Blueprint.
 6. In the **Settings** section, create a `.mobileconfig` file with the following content and upload it:
 
 ```xml
@@ -175,7 +157,7 @@ The configuration includes the UUID of the SCEP library item, so you must [creat
             <key>TeamSlug</key>
             <string>YOUR-TEAM-SLUG</string>
             <key>Certificate</key>
-            <string>mackms:label=step-agent-bootstrap SCEP_LIBRARY_ITEM_UUID;se=false;tag=</string>
+            <string>mackms:ou=$BLUEPRINT_ID;l=step-agent-bootstrap;se=false;tag=</string>
         </dict>
     </array>
     <key>PayloadDisplayName</key>
@@ -194,17 +176,9 @@ The configuration includes the UUID of the SCEP library item, so you must [creat
 
     Replace `YOUR-TEAM-SLUG` with your actual team slug from Smallstep.
 
-    Replace `SCEP_LIBRARY_ITEM_UUID` with the UUID of the SCEP library item you copied earlier. The agent looks up its certificate by an exact, case-sensitive match on this label, and the label must match the issued certificate's Common Name: `step-agent-bootstrap`, followed by a single space, followed by the UUID. For example:
-
-    ```
-    mackms:label=step-agent-bootstrap 0be2373f-40ce-4675-8a97-c25a2b0e51b2;se=false;tag=
-    ```
+    Leave `$BLUEPRINT_ID` as-is; Iru replaces it with the assigned Blueprint's ID when it deploys the profile. The `ou` and `l` values in the `Certificate` URI must match the `OU` and `L` components of the SCEP profile's Subject, which is why both library items must be assigned to the same Blueprint.
 
 7. Choose **Save**
-
-<Aside>
-Do not use Iru's `$PROFILE_UUID` variable in this Custom Profile. Iru variables render the UUID of the library item they appear in, so `$PROFILE_UUID` here produces the Custom Profile's own UUID, not the SCEP library item's, and the agent will never find its certificate. Paste the SCEP library item's UUID as a literal value.
-</Aside>
 
 #### Configure Login Items (macOS)
 

--- a/tutorials/connect-iru-to-smallstep.mdx
+++ b/tutorials/connect-iru-to-smallstep.mdx
@@ -106,8 +106,7 @@ Keep this page open or save these values temporarily — you'll need them for th
     - Enable **Automatic profile redistribution**, and set the number of days before certificate expiration when Iru should redistribute the profile (Iru defaults to 30 days). This is what lets the agent's enrollment certificate renew before it expires.
 7. Choose **Save**
 
-A note on the Subject: with automatic profile redistribution enabled, Iru puts the SCEP profile's UUID in the Common Name, so the CN isn't a stable way to identify the certificate. The other two components give the agent stable values to search on instead. Iru replaces `$BLUEPRINT_ID` with the ID of the assigned Blueprint, and `L=step-agent-bootstrap` is a fixed marker value. The agent configuration below looks up the certificate by these two fields.
-
+A note on the Subject: Iru replaces `$BLUEPRINT_ID` with the ID of the assigned Blueprint, and `L=step-agent-bootstrap` is a fixed marker value. In the agent configuration below, the agent uses these fields to look up the certificate on the device.
 ## Install the Smallstep Agent
 
 There are two ways to install the agent:

--- a/tutorials/connect-iru-to-smallstep.mdx
+++ b/tutorials/connect-iru-to-smallstep.mdx
@@ -1,5 +1,5 @@
 ---
-updated_at: March 24, 2026
+updated_at: July 14, 2026
 title: Connect Iru (Kandji) to Smallstep
 html_title: Integrate Iru (Kandji) with Smallstep Tutorial
 description: Integrate Iru (Kandji) with Smallstep for Apple device security. Complete guide for enforcing device trust in macOS environments.
@@ -101,8 +101,28 @@ Keep this page open or save these values temporarily — you'll need them for th
       - Value: `deviceid:$DEVICE_ID`
     - **Key Size**: `2048`
     - **Key Usage**: `Both signing and encryption`
-6. In the **Additional Options** section, enable **Allow all apps to access the private key**
+6. In the **Additional Options** section, configure the following:
+    - Enable **Allow all apps to access the private key**
+    - Enable **Automatic profile redistribution**, and set the number of days before certificate expiration when Iru should redistribute the profile (Iru defaults to 30 days). This is what lets the agent's enrollment certificate renew before it expires.
 7. Choose **Save**
+
+When automatic profile redistribution is enabled, Iru appends the SCEP library item's UUID (its `$PROFILE_UUID` value) to the Subject on every request. The Common Name of the issued certificate will be `step-agent-bootstrap <uuid>` (with a single space before the UUID) rather than `step-agent-bootstrap` alone. The agent configuration below must reference this full name.
+
+### Copy the SCEP Library Item UUID
+
+The agent configuration in the next section requires the UUID of the SCEP library item you just created, so the SCEP library item must exist before you create the agent's Custom Profile.
+
+The UUID is the last path segment of the library item's URL in your browser's address bar:
+
+```
+https://<your-tenant>.iru.com/library/scep/<UUID>
+```
+
+Copy the UUID and save it temporarily. You'll need it when configuring the agent settings below.
+
+<Aside>
+Deleting and recreating the SCEP library item generates a new UUID. That breaks certificate renewal on every enrolled device until you update the agent configuration to match the new UUID.
+</Aside>
 
 ## Install the Smallstep Agent
 
@@ -125,7 +145,9 @@ There are two ways to install the agent:
 
 #### Configure the Agent Settings
 
-The Smallstep Agent requires configuration settings to connect to your Smallstep team. Deploy these via a Custom Profile:
+The Smallstep Agent requires configuration settings to connect to your Smallstep team. Deploy these via a Custom Profile.
+
+The configuration includes the UUID of the SCEP library item, so you must [create the SCEP library item](#create-a-scep-profile-in-iru) and copy its UUID before creating this profile.
 
 1. In the Smallstep console, choose ⚙️ **Settings** and temporarily save the **Team Slug** value
 2. In the Iru sidebar, choose **Library**
@@ -153,7 +175,7 @@ The Smallstep Agent requires configuration settings to connect to your Smallstep
             <key>TeamSlug</key>
             <string>YOUR-TEAM-SLUG</string>
             <key>Certificate</key>
-            <string>mackms:label=step-agent-bootstrap;se=false;tag=</string>
+            <string>mackms:label=step-agent-bootstrap SCEP_LIBRARY_ITEM_UUID;se=false;tag=</string>
         </dict>
     </array>
     <key>PayloadDisplayName</key>
@@ -172,7 +194,17 @@ The Smallstep Agent requires configuration settings to connect to your Smallstep
 
     Replace `YOUR-TEAM-SLUG` with your actual team slug from Smallstep.
 
+    Replace `SCEP_LIBRARY_ITEM_UUID` with the UUID of the SCEP library item you copied earlier. The agent looks up its certificate by an exact, case-sensitive match on this label, and the label must match the issued certificate's Common Name: `step-agent-bootstrap`, followed by a single space, followed by the UUID. For example:
+
+    ```
+    mackms:label=step-agent-bootstrap 0be2373f-40ce-4675-8a97-c25a2b0e51b2;se=false;tag=
+    ```
+
 7. Choose **Save**
+
+<Aside>
+Do not use Iru's `$PROFILE_UUID` variable in this Custom Profile. Iru variables render the UUID of the library item they appear in, so `$PROFILE_UUID` here produces the Custom Profile's own UUID, not the SCEP library item's, and the agent will never find its certificate. Paste the SCEP library item's UUID as a literal value.
+</Aside>
 
 #### Configure Login Items (macOS)
 

--- a/tutorials/connect-iru-to-smallstep.mdx
+++ b/tutorials/connect-iru-to-smallstep.mdx
@@ -121,7 +121,7 @@ https://<your-tenant>.iru.com/library/scep/<UUID>
 Copy the UUID and save it temporarily. You'll need it when configuring the agent settings below.
 
 <Aside>
-Deleting and recreating the SCEP library item generates a new UUID. That breaks certificate renewal on every enrolled device until you update the agent configuration to match the new UUID.
+Deleting and recreating the SCEP library item generates a new UUID. That breaks the Smallstep Agent on every enrolled device until you update the agent configuration to match the new UUID.
 </Aside>
 
 ## Install the Smallstep Agent

--- a/tutorials/connect-iru-to-smallstep.mdx
+++ b/tutorials/connect-iru-to-smallstep.mdx
@@ -134,7 +134,7 @@ The Smallstep Agent requires configuration settings to connect to your Smallstep
 2. In the Iru sidebar, choose **Library**
 3. Choose **Add Library Item**, then select **Custom Profile**, and click **Add and Configure**
 4. Set a title (e.g., `Smallstep Agent Configuration`)
-5. Under **Assignment**, choose the same Blueprint you assigned to the SCEP profile. This is required: Iru renders `$BLUEPRINT_ID` in both library items, and the values only match when both are assigned to the same Blueprint.
+5. Under **Assignment**, choose the same Blueprint you assigned to the SCEP profile. This is required for the agent to find the certificate.
 6. In the **Settings** section, create a `.mobileconfig` file with the following content and upload it:
 
 ```xml


### PR DESCRIPTION
#### Describe your changes:

The Iru (Kandji) tutorial's agent configuration only works while SCEP certificate renewal is off. When **Automatic profile redistribution** is enabled on the SCEP library item, Iru puts the SCEP profile's UUID in the certificate Subject's CN, the keychain label changes, and the agent's exact-match certificate lookup fails — the agent can never start after the first renewal.

Since Iru requires the CN to carry the profile identifier, the CN isn't a stable lookup key. This updates the tutorial to identify the certificate by stable DN components instead:

- Enable **Automatic profile redistribution** in the SCEP profile steps so the enrollment certificate renews
- SCEP profile Subject becomes `CN=$PROFILE_UUID,OU=$BLUEPRINT_ID,L=step-agent-bootstrap`
- Agent `Certificate` value becomes `mackms:ou=$BLUEPRINT_ID;l=step-agent-bootstrap;se=false;tag=`
- The SCEP library item and the agent Custom Profile must be assigned to the same Blueprint so `$BLUEPRINT_ID` renders identically in both

⚠️ **Do not merge yet** — this documents agent behavior that hasn't shipped: `mackms:` lookup by `ou`/`l` Subject components (today it only supports `label`/`serial`/`keychain`). Merge once the agent change is released.

Verified with vale and markdown-link-check, and rendered locally via `pnpm dev`.

#### Related links/other PRs/issues:

EFF-433

Thank you!

🤖 Generated with [Claude Code](https://claude.com/claude-code)