### PR TITLE
Link Intune tutorial to evergreen .intunewin URLs

### DIFF
--- a/tutorials/connect-intune-to-smallstep.mdx
+++ b/tutorials/connect-intune-to-smallstep.mdx
@@ -101,7 +101,7 @@ In this step, we’ll add the Smallstep Agent to Intune for distribution to devi
 1. In Intune,
     1. Start at [Windows Apps](https://intune.microsoft.com/#view/Microsoft_Intune_DeviceSettings/AppsWindowsMenu/~/windowsApps)
     2. Choose **+ Create**, and then select **Windows App (Win32)**
-    3. [Download the Smallstep agent `.intunewin` package for `amd64`](https://files.smallstep.com/intune/step-agent-plugin_amd64.intunewin) and select it for upload in Intune. (Contact Smallstep if you need an `arm64` installer).
+    3. Download the Smallstep agent `.intunewin` package for [`amd64`](https://packages.smallstep.com/stable/windows/step-agent_amd64_latest.intunewin) or [`arm64`](https://packages.smallstep.com/stable/windows/step-agent_arm64_latest.intunewin) and select it for upload in Intune.
     - For the App Information tab:
         - For Publisher, use “Smallstep”
         - Note the version number. You'll need it below.


### PR DESCRIPTION
Replaces the hand-maintained `files.smallstep.com/intune/step-agent-plugin_amd64.intunewin` link (stale since 2025-09) with the stable-channel `_latest` pointers on packages.smallstep.com, which refresh on every release promotion. Also links the `arm64` package directly — CI has shipped it for a while — instead of "contact us".

**Merge order:** hold until smallstep/agent#1207 merges and a promotion runs (re-running promote for v0.68.0 works — it's idempotent); the `_latest.intunewin` URLs 404 until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3b91ygScLGY4tpBtzUsG4