### PR TITLE
Tutorials: get the Authority ID from the authority detail page

### DIFF
--- a/tutorials/protect-github-ssh.mdx
+++ b/tutorials/protect-github-ssh.mdx
@@ -1,5 +1,5 @@
 ---
-updated_at: July 08, 2026
+updated_at: September 02, 2026
 title: Protect GitHub with SSH Certificates
 html_title: Protect GitHub Repositories with Hardware-Bound SSH Certificates
 description: Authenticate to GitHub with short-lived SSH certificates backed by your device's TPM or Secure Enclave, issued and managed by the Smallstep Agent.
@@ -117,15 +117,9 @@ echo "Authorization: Bearer [your API token]" > api_headers
 set -o history
 ```
 
-Find the authority that should issue your SSH certificates with the
-[List Authorities](https://gateway.smallstep.com/v2025-01-01/operations/GetAuthorities) endpoint:
-
-```bash
-curl -sH @api_headers --request GET \
-  --url https://gateway.smallstep.com/api/authorities \
-  --header 'Accept: application/json' \
-  --header 'x-smallstep-api-version: 2025-01-01' | jq '.[] | {id, name, domain}'
-```
+Next, choose the SSH authority that should issue your SSH certificates.
+In the Smallstep dashboard, go to **Certificate Manager → Authorities**, open the authority,
+and copy its **Authority ID** from the **Authority Settings** panel.
 
 Then create the credential with the [Create Credential](https://gateway.smallstep.com/v2025-01-01/operations/PostCredentials) endpoint:
 

--- a/tutorials/protect-wired-networks.mdx
+++ b/tutorials/protect-wired-networks.mdx
@@ -1,5 +1,5 @@
 ---
-updated_at: July 08, 2026
+updated_at: September 02, 2026
 title: Protect Wired Networks with 802.1X EAP-TLS
 html_title: Protect Wired Networks with 802.1X EAP-TLS Certificates and Smallstep
 description: Set up certificate-based Ethernet access. Issue client certificates via the Smallstep API, configure RADIUS and your switches, and deploy to clients.
@@ -47,16 +47,11 @@ echo "Authorization: Bearer [your API token]" > api_headers
 set -o history
 ```
 
-Find the authority that should issue your client certificates with the
-[List Authorities](https://gateway.smallstep.com/v2025-01-01/operations/GetAuthorities) endpoint,
-and save its `id` and `root` certificate:
-
-```bash
-curl -sH @api_headers --request GET \
-  --url https://gateway.smallstep.com/api/authorities \
-  --header 'Accept: application/json' \
-  --header 'x-smallstep-api-version: 2025-01-01' | jq '.[] | {id, name, domain}'
-```
+Next, choose the authority that should issue your client certificates.
+In the Smallstep dashboard, go to **Certificate Manager → Authorities** and open the authority.
+From the **Authority Settings** panel, copy the **Authority ID**,
+and download the **Root Certificate** as `client_ca.crt`.
+You'll register the root certificate with your RADIUS server in Step 2.
 
 Then create the credential with the [Create Credential](https://gateway.smallstep.com/v2025-01-01/operations/PostCredentials) endpoint:
 

--- a/tutorials/protect-wireless-networks.mdx
+++ b/tutorials/protect-wireless-networks.mdx
@@ -1,5 +1,5 @@
 ---
-updated_at: July 08, 2026
+updated_at: September 02, 2026
 title: Protect Wireless Networks with 802.1X EAP-TLS
 html_title: Protect Wireless Networks with 802.1X EAP-TLS Certificates and Smallstep
 description: Set up certificate-based Wi-Fi end to end. Issue client certificates via the Smallstep API, configure RADIUS and access points, and deploy to clients.
@@ -100,29 +100,15 @@ set -o history
 ## Find your authority
 
 Certificates are issued by one of your team's X.509 authorities.
-Use the [List Authorities](https://gateway.smallstep.com/v2025-01-01/operations/GetAuthorities) endpoint to find the authority
-that should issue your Wi-Fi client certificates:
+In the Smallstep dashboard, go to **Certificate Manager → Authorities**
+and open the authority that should issue your Wi-Fi client certificates.
 
-```bash
-curl -sH @api_headers --request GET \
-  --url https://gateway.smallstep.com/api/authorities \
-  --header 'Accept: application/json' \
-  --header 'x-smallstep-api-version: 2025-01-01' | jq '.[] | {id, name, domain}'
-```
+Save two values from the **Authority Settings** panel:
 
-Save two values from the authority you choose:
-
-- The `id`, which you'll use as the `authorityID` when creating the credential.
-- The `root` certificate (PEM), which you'll register with your RADIUS server in Step 2
-  so it can verify client certificates issued by this authority:
-
-```bash
-curl -sH @api_headers --request GET \
-  --url https://gateway.smallstep.com/api/authorities \
-  --header 'Accept: application/json' \
-  --header 'x-smallstep-api-version: 2025-01-01' \
-  | jq -r '.[] | select(.id == "[your authority ID]") | .root' > client_ca.crt
-```
+- The **Authority ID**, which you'll use as the `authorityID` when creating the credential.
+- The **Root Certificate**, which you'll register with your RADIUS server in Step 2
+  so it can verify client certificates issued by this authority.
+  Download it and save it as `client_ca.crt`.
 
 ## Create the credential
 


### PR DESCRIPTION
Certificate Manager now shows the **Authority ID** directly on the authority detail page (Authority Settings panel), next to the root certificate download. The three agent-credential tutorials made readers find the ID with a List Authorities API call and `jq`; this replaces that with a pointer to the page.

- `tutorials/protect-wired-networks.mdx`
- `tutorials/protect-wireless-networks.mdx`
- `tutorials/protect-github-ssh.mdx`

Also fixes a gap in the wired tutorial: it said to save the root certificate but never showed how, then used `client_ca.crt` in Step 2. The Root Certificate download on the detail page covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ls5vRnPQF7bFoaNueQc54h